### PR TITLE
Add definitions for Postgres' bytea type

### DIFF
--- a/internal/codegen/golang/gotype/known_types.go
+++ b/internal/codegen/golang/gotype/known_types.go
@@ -44,6 +44,7 @@ var (
 	Float32Slice = NewOpaqueType("[]float32")
 	Float64      = NewOpaqueType("float64")
 	Float64Slice = NewOpaqueType("[]float64")
+	ByteSlice    = NewOpaqueType("[]byte")
 
 	// pgtype types prefixed with "pg".
 	PgBool             = NewOpaqueType("github.com/jackc/pgtype.Bool")
@@ -53,6 +54,7 @@ var (
 	PgInt2             = NewOpaqueType("github.com/jackc/pgtype.Int2")
 	PgInt4             = NewOpaqueType("github.com/jackc/pgtype.Int4")
 	PgText             = NewOpaqueType("github.com/jackc/pgtype.Text")
+	PgBytea            = NewOpaqueType("github.com/jackc/pgtype.Bytea")
 	PgOID              = NewOpaqueType("github.com/jackc/pgtype.OID")
 	PgTID              = NewOpaqueType("github.com/jackc/pgtype.TID")
 	PgXID              = NewOpaqueType("github.com/jackc/pgtype.XID")
@@ -127,6 +129,7 @@ var knownTypesByOID = map[pgtype.OID]knownGoType{
 	pgtype.Int2OID:             {PgInt2, Int16},
 	pgtype.Int4OID:             {PgInt4, Int32},
 	pgtype.TextOID:             {PgText, String},
+	pgtype.ByteaOID:            {PgBytea, ByteSlice},
 	pgtype.OIDOID:              {PgOID, nil},
 	pgtype.TIDOID:              {PgTID, nil},
 	pgtype.XIDOID:              {PgXID, nil},

--- a/internal/pg/types.go
+++ b/internal/pg/types.go
@@ -201,6 +201,7 @@ var (
 
 	typeMap = map[pgtype.OID]Type{
 		pgtype.BoolOID:             Bool,
+		pgtype.ByteaOID:            Bytea,
 		pgtype.QCharOID:            QChar,
 		pgtype.NameOID:             Name,
 		pgtype.Int8OID:             Int8,


### PR DESCRIPTION
I was surprised that pggen doesn't support `bytea` columns. Was that intentional?
I've added the necessary type definitions and successfully used the result.

I've also tried to use `--go-type 'bytea=github.com/jackc/pgtype.Bytea'` but that doesn't work since pggen still complains about the missing OID: https://github.com/jschaf/pggen/blob/7f6f84eb1636947992128675bddf9b33c5e2d557/internal/pg/types.go#L355-L361

Did I misunderstand how `--go-type` is supposed to work or does it only allow remapping known OIDs to different Go types?