### PR TITLE
Fix order by column exist in explain output

### DIFF
--- a/example/author/query.sql
+++ b/example/author/query.sql
@@ -6,6 +6,10 @@ SELECT * FROM author WHERE author_id = pggen.arg('AuthorID');
 -- name: FindAuthors :many
 SELECT * FROM author WHERE first_name = pggen.arg('FirstName');
 
+-- FindAuthorNames finds one (or zero) authors by ID.
+-- name: FindAuthorNames :many
+SELECT first_name,last_name FROM author ORDER BY author_id = pggen.arg('AuthorID');
+
 -- DeleteAuthors deletes authors with a first name of "joe".
 -- name: DeleteAuthors :exec
 DELETE FROM author WHERE first_name = 'joe';

--- a/internal/pginfer/pginfer.go
+++ b/internal/pginfer/pginfer.go
@@ -3,14 +3,15 @@ package pginfer
 import (
 	"context"
 	"fmt"
+	"strings"
+	"time"
+
 	"github.com/jackc/pgproto3/v2"
 	"github.com/jackc/pgtype"
 	"github.com/jackc/pgx/v4"
 	"github.com/jschaf/pggen/internal/ast"
 	"github.com/jschaf/pggen/internal/errs"
 	"github.com/jschaf/pggen/internal/pg"
-	"strings"
-	"time"
 )
 
 const defaultTimeout = 3 * time.Second
@@ -238,6 +239,9 @@ func (inf *Inferrer) inferOutputNullability(query *ast.SourceQuery, descs []pgpr
 	// nullable.
 	nullables := make([]bool, len(descs))
 	for i, out := range plan.Outputs {
+		if i == len(cols) {
+			break
+		}
 		nullables[i] = isColNullable(query, plan, out, cols[i])
 	}
 	return nullables, nil


### PR DESCRIPTION
When generating code for a PostgreSQL request like this:

```
SELECT col1 ORDER BY col2
```

after executing the code generator, panic occurs:

```
=== RUN   TestGenerate_Go_Example_Author
    /Users/ivk/work/pggen/example/author/codegen_test.go:13: created schema: pggen_test_653479730
--- FAIL: TestGenerate_Go_Example_Author (0.13s)
panic: runtime error: index out of range [2] with length 2 [recovered]
	panic: runtime error: index out of range [2] with length 2

goroutine 6 [running]:
testing.tRunner.func1.1(0x17edba0, 0xc000416ae0)
	/usr/local/Cellar/go/1.15.2/libexec/src/testing/testing.go:1076 +0x30d
testing.tRunner.func1(0xc000001c80)
	/usr/local/Cellar/go/1.15.2/libexec/src/testing/testing.go:1079 +0x41a
panic(0x17edba0, 0xc000416ae0)
	/usr/local/Cellar/go/1.15.2/libexec/src/runtime/panic.go:969 +0x175
github.com/jschaf/pggen/internal/pginfer.(*Inferrer).inferOutputNullability(0xc00037a790, 0xc000382d90, 0xc000110180, 0x2, 0x2, 0x0, 0x0, 0x1, 0x1921e00, 0xc0003af1d8)
	/Users/ivk/work/pggen/internal/pginfer/pginfer.go:241 +0x4f7
github.com/jschaf/pggen/internal/pginfer.(*Inferrer).inferOutputTypes(0xc00037a790, 0xc000382d90, 0x0, 0x0, 0x0, 0x0, 0x0)
	/Users/ivk/work/pggen/internal/pginfer/pginfer.go:190 +0x3ee
github.com/jschaf/pggen/internal/pginfer.(*Inferrer).InferTypes(0xc00037a790, 0xc000382d90, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/Users/ivk/work/pggen/internal/pginfer/pginfer.go:81 +0x18a
github.com/jschaf/pggen.parseQueries(0x1838768, 0x9, 0xc00037a790, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x17708c0)
	/Users/ivk/work/pggen/generate.go:214 +0x513
github.com/jschaf/pggen.parseQueryFiles(0xc0004122f0, 0x1, 0x1, 0xc00037a790, 0xc00042a000, 0x65, 0xc0004122f0, 0x1, 0x1)
	/Users/ivk/work/pggen/generate.go:178 +0xc5
github.com/jschaf/pggen.Generate(0x1835da8, 0x2, 0xc00042a000, 0x65, 0xc0004122f0, 0x1, 0x1, 0x0, 0x0, 0x0, ...)
	/Users/ivk/work/pggen/generate.go:103 +0x4d3
github.com/jschaf/pggen/example/author.TestGenerate_Go_Example_Author(0xc000001c80)
	/Users/ivk/work/pggen/example/author/codegen_test.go:17 +0x1fb
testing.tRunner(0xc000001c80, 0x1863cd0)
	/usr/local/Cellar/go/1.15.2/libexec/src/testing/testing.go:1127 +0xef
created by testing.(*T).Run
	/usr/local/Cellar/go/1.15.2/libexec/src/testing/testing.go:1178 +0x386
FAIL	github.com/jschaf/pggen/example/author	0.307s
```

After debug, I found out that for some reason in the `EXPLAIN` command output in the `Output` field there is an extra value with the name of the column that is mentioned in `ORDER BY` clause.

It turns out that the length of `plan.Outputs` is not always equal to the length of the array with column names (`cols`)