### PR TITLE
Update `go get` URL in README to actually install the command

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ other than `~/bin/pggen`.
 Requires Go 1.16 because pggen uses `go:embed`.
 
 ```shell
-go get github.com/jschaf/pggen
+go get github.com/jschaf/pggen/cmd/pggen
 ```
     
 Make sure pggen works:


### PR DESCRIPTION
Without the `cmd/pggen` suffix the source is downloaded, but it is not actually compiled into a binary.