### PR TITLE
Add non-nullability support for LIMIT queries

### DIFF
--- a/internal/pginfer/explain.go
+++ b/internal/pginfer/explain.go
@@ -12,6 +12,7 @@ type PlanType string
 
 const (
 	PlanResult      PlanType = "Result"      // select statement
+	PlanLimit       PlanType = "Limit"       // select statement with a limit
 	PlanModifyTable PlanType = "ModifyTable" // update, insert, or delete statement
 )
 

--- a/internal/pginfer/nullability.go
+++ b/internal/pginfer/nullability.go
@@ -24,10 +24,10 @@ func isColNullable(query *ast.SourceQuery, plan Plan, out string, column pg.Colu
 		// try below
 	}
 
-	// A plain select query with no joins where the column comes from a table and
-	// has a not-null constraint. Not full proof because of cross-join with comma
-	// syntax.
-	if plan.Type == PlanResult &&
+	// A plain select query (possibly with a LIMIT clause) with no joins where
+	// the column comes from a table and has a not-null constraint. Not full
+	// proof because of cross-join with comma syntax.
+	if (plan.Type == PlanResult || plan.Type == PlanLimit) &&
 		!strings.Contains(strings.ToLower(query.PreparedSQL), "join") &&
 		!column.Null {
 		return false


### PR DESCRIPTION
Currently, a simple query with a LIMIT clause appended makes all the fields returned nullable. As far as I can tell from the postgres documentation, LIMIT never makes a non-nullable column nullable (this matches intuition as well). Therefore, this should be safe to merge without breaking any functionality.
