### PR TITLE
Fix primitive array types inside a composite type

### DIFF
--- a/example/acceptance_test.go
+++ b/example/acceptance_test.go
@@ -54,6 +54,8 @@ func TestExamples(t *testing.T) {
 			args: []string{
 				"--schema-glob", "example/composite/schema.sql",
 				"--query-glob", "example/composite/query.sql",
+				"--go-type", "_bool=[]bool",
+				"--go-type", "bool=bool",
 				"--go-type", "int8=int",
 				"--go-type", "int4=int",
 				"--go-type", "text=string",
@@ -71,6 +73,8 @@ func TestExamples(t *testing.T) {
 			args: []string{
 				"--schema-glob", "example/slices/schema.sql",
 				"--query-glob", "example/slices/query.sql",
+				"--go-type", "_bool=[]bool",
+				"--go-type", "bool=bool",
 				"--go-type", "timestamp=*time.Time",
 				"--go-type", "_timestamp=[]*time.Time",
 				"--go-type", "timestamptz=*time.Time",

--- a/example/composite/codegen_test.go
+++ b/example/composite/codegen_test.go
@@ -22,9 +22,11 @@ func TestGenerate_Go_Example_Composite(t *testing.T) {
 			GoPackage:  "composite",
 			Language:   pggen.LangGo,
 			TypeOverrides: map[string]string{
-				"int4": "int",
-				"int8": "int",
-				"text": "string",
+				"_bool": "[]bool",
+				"bool":  "bool",
+				"int8":  "int",
+				"int4":  "int",
+				"text":  "string",
 			},
 		})
 	if err != nil {

--- a/example/composite/query.sql
+++ b/example/composite/query.sql
@@ -28,3 +28,7 @@ INSERT
 INTO blocks (screenshot_id, body)
 VALUES (pggen.arg('ScreenshotID'), pggen.arg('Body'))
 RETURNING id, screenshot_id, body;
+
+
+-- name: ArraysInput :one
+SELECT pggen.arg('arrays')::arrays;

--- a/example/composite/schema.sql
+++ b/example/composite/schema.sql
@@ -7,3 +7,10 @@ CREATE TABLE blocks (
   screenshot_id bigint NOT NULL REFERENCES screenshots (id),
   body          text NOT NULL
 );
+
+CREATE TYPE arrays AS (
+  texts  text[],
+  int8s  int8[],
+  bools  boolean[],
+  floats float8[]
+);

--- a/example/slices/codegen_test.go
+++ b/example/slices/codegen_test.go
@@ -23,6 +23,8 @@ func TestGenerate_Go_Example_Slices(t *testing.T) {
 			GoPackage:  "slices",
 			Language:   pggen.LangGo,
 			TypeOverrides: map[string]string{
+				"_bool":        "[]bool",
+				"bool":         "bool",
 				"timestamp":    "*time.Time",
 				"_timestamp":   "[]*time.Time",
 				"timestamptz":  "*time.Time",

--- a/example/slices/query.sql
+++ b/example/slices/query.sql
@@ -1,3 +1,6 @@
+-- name: GetBools :one
+SELECT pggen.arg('data')::boolean[];
+
 -- name: GetOneTimestamp :one
 SELECT pggen.arg('data')::timestamp;
 

--- a/internal/ptrs/ptrs.go
+++ b/internal/ptrs/ptrs.go
@@ -1,0 +1,5 @@
+package ptrs
+
+func NewInt(n int) *int { return &n }
+
+func NewFloat64(f float64) *float64 { return &f }


### PR DESCRIPTION
Previously, we would attempt to create a newArrayInit function, but instead we
can use the pgtype array variants, like pgtype.BoolArray.