### PR TITLE
fix: use struct field names in generated code

### DIFF
--- a/example/author/query.sql.go
+++ b/example/author/query.sql.go
@@ -541,7 +541,7 @@ type textPreferrer struct {
 func (t textPreferrer) PreferredParamFormat() int16 { return pgtype.TextFormatCode }
 
 func (t textPreferrer) NewTypeValue() pgtype.Value {
-	return textPreferrer{pgtype.NewValue(t.ValueTranscoder).(pgtype.ValueTranscoder), t.typeName}
+	return textPreferrer{ValueTranscoder: pgtype.NewValue(t.ValueTranscoder).(pgtype.ValueTranscoder), typeName: t.typeName}
 }
 
 func (t textPreferrer) TypeName() string {

--- a/example/complex_params/query.sql.go
+++ b/example/complex_params/query.sql.go
@@ -226,7 +226,7 @@ func (tr *typeResolver) newCompositeValue(name string, fields ...compositeField)
 	// names does not equal the number of ValueTranscoders.
 	typ, _ := pgtype.NewCompositeTypeValues(name, fs, vals)
 	if !isBinaryOk {
-		return textPreferrer{typ, name}
+		return textPreferrer{ValueTranscoder: typ, typeName: name}
 	}
 	return typ
 }
@@ -245,7 +245,7 @@ func (tr *typeResolver) newArrayValue(name, elemName string, defaultVal func() p
 	}
 	typ := pgtype.NewArrayType(name, elemOID, elemValFunc)
 	if elemOID == unknownOID {
-		return textPreferrer{typ, name}
+		return textPreferrer{ValueTranscoder: typ, typeName: name}
 	}
 	return typ
 }
@@ -255,8 +255,8 @@ func (tr *typeResolver) newArrayValue(name, elemName string, defaultVal func() p
 func (tr *typeResolver) newDimensions() pgtype.ValueTranscoder {
 	return tr.newCompositeValue(
 		"dimensions",
-		compositeField{"width", "int4", &pgtype.Int4{}},
-		compositeField{"height", "int4", &pgtype.Int4{}},
+		compositeField{name: "width", typeName: "int4", defaultVal: &pgtype.Int4{}},
+		compositeField{name: "height", typeName: "int4", defaultVal: &pgtype.Int4{}},
 	)
 }
 
@@ -280,9 +280,9 @@ func (tr *typeResolver) newDimensionsRaw(v Dimensions) []interface{} {
 func (tr *typeResolver) newProductImageSetType() pgtype.ValueTranscoder {
 	return tr.newCompositeValue(
 		"product_image_set_type",
-		compositeField{"name", "text", &pgtype.Text{}},
-		compositeField{"orig_image", "product_image_type", tr.newProductImageType()},
-		compositeField{"images", "_product_image_type", tr.newProductImageTypeArray()},
+		compositeField{name: "name", typeName: "text", defaultVal: &pgtype.Text{}},
+		compositeField{name: "orig_image", typeName: "product_image_type", defaultVal: tr.newProductImageType()},
+		compositeField{name: "images", typeName: "_product_image_type", defaultVal: tr.newProductImageTypeArray()},
 	)
 }
 
@@ -307,8 +307,8 @@ func (tr *typeResolver) newProductImageSetTypeRaw(v ProductImageSetType) []inter
 func (tr *typeResolver) newProductImageType() pgtype.ValueTranscoder {
 	return tr.newCompositeValue(
 		"product_image_type",
-		compositeField{"source", "text", &pgtype.Text{}},
-		compositeField{"dimensions", "dimensions", tr.newDimensions()},
+		compositeField{name: "source", typeName: "text", defaultVal: &pgtype.Text{}},
+		compositeField{name: "dimensions", typeName: "dimensions", defaultVal: tr.newDimensions()},
 	)
 }
 
@@ -539,7 +539,7 @@ type textPreferrer struct {
 func (t textPreferrer) PreferredParamFormat() int16 { return pgtype.TextFormatCode }
 
 func (t textPreferrer) NewTypeValue() pgtype.Value {
-	return textPreferrer{pgtype.NewValue(t.ValueTranscoder).(pgtype.ValueTranscoder), t.typeName}
+	return textPreferrer{ValueTranscoder: pgtype.NewValue(t.ValueTranscoder).(pgtype.ValueTranscoder), typeName: t.typeName}
 }
 
 func (t textPreferrer) TypeName() string {

--- a/example/composite/query.sql.go
+++ b/example/composite/query.sql.go
@@ -228,7 +228,7 @@ func (tr *typeResolver) newCompositeValue(name string, fields ...compositeField)
 	// names does not equal the number of ValueTranscoders.
 	typ, _ := pgtype.NewCompositeTypeValues(name, fs, vals)
 	if !isBinaryOk {
-		return textPreferrer{typ, name}
+		return textPreferrer{ValueTranscoder: typ, typeName: name}
 	}
 	return typ
 }
@@ -247,7 +247,7 @@ func (tr *typeResolver) newArrayValue(name, elemName string, defaultVal func() p
 	}
 	typ := pgtype.NewArrayType(name, elemOID, elemValFunc)
 	if elemOID == unknownOID {
-		return textPreferrer{typ, name}
+		return textPreferrer{ValueTranscoder: typ, typeName: name}
 	}
 	return typ
 }
@@ -257,10 +257,10 @@ func (tr *typeResolver) newArrayValue(name, elemName string, defaultVal func() p
 func (tr *typeResolver) newArrays() pgtype.ValueTranscoder {
 	return tr.newCompositeValue(
 		"arrays",
-		compositeField{"texts", "_text", &pgtype.TextArray{}},
-		compositeField{"int8s", "_int8", &pgtype.Int8Array{}},
-		compositeField{"bools", "_bool", &pgtype.BoolArray{}},
-		compositeField{"floats", "_float8", &pgtype.Float8Array{}},
+		compositeField{name: "texts", typeName: "_text", defaultVal: &pgtype.TextArray{}},
+		compositeField{name: "int8s", typeName: "_int8", defaultVal: &pgtype.Int8Array{}},
+		compositeField{name: "bools", typeName: "_bool", defaultVal: &pgtype.BoolArray{}},
+		compositeField{name: "floats", typeName: "_float8", defaultVal: &pgtype.Float8Array{}},
 	)
 }
 
@@ -286,9 +286,9 @@ func (tr *typeResolver) newArraysRaw(v Arrays) []interface{} {
 func (tr *typeResolver) newBlocks() pgtype.ValueTranscoder {
 	return tr.newCompositeValue(
 		"blocks",
-		compositeField{"id", "int4", &pgtype.Int4{}},
-		compositeField{"screenshot_id", "int8", &pgtype.Int8{}},
-		compositeField{"body", "text", &pgtype.Text{}},
+		compositeField{name: "id", typeName: "int4", defaultVal: &pgtype.Int4{}},
+		compositeField{name: "screenshot_id", typeName: "int8", defaultVal: &pgtype.Int8{}},
+		compositeField{name: "body", typeName: "text", defaultVal: &pgtype.Text{}},
 	)
 }
 
@@ -297,8 +297,8 @@ func (tr *typeResolver) newBlocks() pgtype.ValueTranscoder {
 func (tr *typeResolver) newUserEmail() pgtype.ValueTranscoder {
 	return tr.newCompositeValue(
 		"user_email",
-		compositeField{"id", "text", &pgtype.Text{}},
-		compositeField{"email", "citext", &pgtype.Text{}},
+		compositeField{name: "id", typeName: "text", defaultVal: &pgtype.Text{}},
+		compositeField{name: "email", typeName: "citext", defaultVal: &pgtype.Text{}},
 	)
 }
 
@@ -593,7 +593,7 @@ type textPreferrer struct {
 func (t textPreferrer) PreferredParamFormat() int16 { return pgtype.TextFormatCode }
 
 func (t textPreferrer) NewTypeValue() pgtype.Value {
-	return textPreferrer{pgtype.NewValue(t.ValueTranscoder).(pgtype.ValueTranscoder), t.typeName}
+	return textPreferrer{ValueTranscoder: pgtype.NewValue(t.ValueTranscoder).(pgtype.ValueTranscoder), typeName: t.typeName}
 }
 
 func (t textPreferrer) TypeName() string {

--- a/example/custom_types/query.sql.go
+++ b/example/custom_types/query.sql.go
@@ -286,7 +286,7 @@ type textPreferrer struct {
 func (t textPreferrer) PreferredParamFormat() int16 { return pgtype.TextFormatCode }
 
 func (t textPreferrer) NewTypeValue() pgtype.Value {
-	return textPreferrer{pgtype.NewValue(t.ValueTranscoder).(pgtype.ValueTranscoder), t.typeName}
+	return textPreferrer{ValueTranscoder: pgtype.NewValue(t.ValueTranscoder).(pgtype.ValueTranscoder), typeName: t.typeName}
 }
 
 func (t textPreferrer) TypeName() string {

--- a/example/device/query.sql.go
+++ b/example/device/query.sql.go
@@ -247,7 +247,7 @@ func (tr *typeResolver) newCompositeValue(name string, fields ...compositeField)
 	// names does not equal the number of ValueTranscoders.
 	typ, _ := pgtype.NewCompositeTypeValues(name, fs, vals)
 	if !isBinaryOk {
-		return textPreferrer{typ, name}
+		return textPreferrer{ValueTranscoder: typ, typeName: name}
 	}
 	return typ
 }
@@ -266,7 +266,7 @@ func (tr *typeResolver) newArrayValue(name, elemName string, defaultVal func() p
 	}
 	typ := pgtype.NewArrayType(name, elemOID, elemValFunc)
 	if elemOID == unknownOID {
-		return textPreferrer{typ, name}
+		return textPreferrer{ValueTranscoder: typ, typeName: name}
 	}
 	return typ
 }
@@ -276,8 +276,8 @@ func (tr *typeResolver) newArrayValue(name, elemName string, defaultVal func() p
 func (tr *typeResolver) newUser() pgtype.ValueTranscoder {
 	return tr.newCompositeValue(
 		"user",
-		compositeField{"id", "int8", &pgtype.Int8{}},
-		compositeField{"name", "text", &pgtype.Text{}},
+		compositeField{name: "id", typeName: "int8", defaultVal: &pgtype.Int8{}},
+		compositeField{name: "name", typeName: "text", defaultVal: &pgtype.Text{}},
 	)
 }
 
@@ -614,7 +614,7 @@ type textPreferrer struct {
 func (t textPreferrer) PreferredParamFormat() int16 { return pgtype.TextFormatCode }
 
 func (t textPreferrer) NewTypeValue() pgtype.Value {
-	return textPreferrer{pgtype.NewValue(t.ValueTranscoder).(pgtype.ValueTranscoder), t.typeName}
+	return textPreferrer{ValueTranscoder: pgtype.NewValue(t.ValueTranscoder).(pgtype.ValueTranscoder), typeName: t.typeName}
 }
 
 func (t textPreferrer) TypeName() string {

--- a/example/domain/query.sql.go
+++ b/example/domain/query.sql.go
@@ -182,7 +182,7 @@ type textPreferrer struct {
 func (t textPreferrer) PreferredParamFormat() int16 { return pgtype.TextFormatCode }
 
 func (t textPreferrer) NewTypeValue() pgtype.Value {
-	return textPreferrer{pgtype.NewValue(t.ValueTranscoder).(pgtype.ValueTranscoder), t.typeName}
+	return textPreferrer{ValueTranscoder: pgtype.NewValue(t.ValueTranscoder).(pgtype.ValueTranscoder), typeName: t.typeName}
 }
 
 func (t textPreferrer) TypeName() string {

--- a/example/enums/query.sql.go
+++ b/example/enums/query.sql.go
@@ -257,7 +257,7 @@ func (tr *typeResolver) newCompositeValue(name string, fields ...compositeField)
 	// names does not equal the number of ValueTranscoders.
 	typ, _ := pgtype.NewCompositeTypeValues(name, fs, vals)
 	if !isBinaryOk {
-		return textPreferrer{typ, name}
+		return textPreferrer{ValueTranscoder: typ, typeName: name}
 	}
 	return typ
 }
@@ -276,7 +276,7 @@ func (tr *typeResolver) newArrayValue(name, elemName string, defaultVal func() p
 	}
 	typ := pgtype.NewArrayType(name, elemOID, elemValFunc)
 	if elemOID == unknownOID {
-		return textPreferrer{typ, name}
+		return textPreferrer{ValueTranscoder: typ, typeName: name}
 	}
 	return typ
 }
@@ -286,8 +286,8 @@ func (tr *typeResolver) newArrayValue(name, elemName string, defaultVal func() p
 func (tr *typeResolver) newDevice() pgtype.ValueTranscoder {
 	return tr.newCompositeValue(
 		"device",
-		compositeField{"mac", "macaddr", &pgtype.Macaddr{}},
-		compositeField{"type", "device_type", newDeviceTypeEnum()},
+		compositeField{name: "mac", typeName: "macaddr", defaultVal: &pgtype.Macaddr{}},
+		compositeField{name: "type", typeName: "device_type", defaultVal: newDeviceTypeEnum()},
 	)
 }
 
@@ -591,7 +591,7 @@ type textPreferrer struct {
 func (t textPreferrer) PreferredParamFormat() int16 { return pgtype.TextFormatCode }
 
 func (t textPreferrer) NewTypeValue() pgtype.Value {
-	return textPreferrer{pgtype.NewValue(t.ValueTranscoder).(pgtype.ValueTranscoder), t.typeName}
+	return textPreferrer{ValueTranscoder: pgtype.NewValue(t.ValueTranscoder).(pgtype.ValueTranscoder), typeName: t.typeName}
 }
 
 func (t textPreferrer) TypeName() string {

--- a/example/erp/order/customer.sql.go
+++ b/example/erp/order/customer.sql.go
@@ -455,7 +455,7 @@ type textPreferrer struct {
 func (t textPreferrer) PreferredParamFormat() int16 { return pgtype.TextFormatCode }
 
 func (t textPreferrer) NewTypeValue() pgtype.Value {
-	return textPreferrer{pgtype.NewValue(t.ValueTranscoder).(pgtype.ValueTranscoder), t.typeName}
+	return textPreferrer{ValueTranscoder: pgtype.NewValue(t.ValueTranscoder).(pgtype.ValueTranscoder), typeName: t.typeName}
 }
 
 func (t textPreferrer) TypeName() string {

--- a/example/function/query.sql.go
+++ b/example/function/query.sql.go
@@ -179,7 +179,7 @@ func (tr *typeResolver) newCompositeValue(name string, fields ...compositeField)
 	// names does not equal the number of ValueTranscoders.
 	typ, _ := pgtype.NewCompositeTypeValues(name, fs, vals)
 	if !isBinaryOk {
-		return textPreferrer{typ, name}
+		return textPreferrer{ValueTranscoder: typ, typeName: name}
 	}
 	return typ
 }
@@ -198,7 +198,7 @@ func (tr *typeResolver) newArrayValue(name, elemName string, defaultVal func() p
 	}
 	typ := pgtype.NewArrayType(name, elemOID, elemValFunc)
 	if elemOID == unknownOID {
-		return textPreferrer{typ, name}
+		return textPreferrer{ValueTranscoder: typ, typeName: name}
 	}
 	return typ
 }
@@ -208,8 +208,8 @@ func (tr *typeResolver) newArrayValue(name, elemName string, defaultVal func() p
 func (tr *typeResolver) newListItem() pgtype.ValueTranscoder {
 	return tr.newCompositeValue(
 		"list_item",
-		compositeField{"name", "text", &pgtype.Text{}},
-		compositeField{"color", "text", &pgtype.Text{}},
+		compositeField{name: "name", typeName: "text", defaultVal: &pgtype.Text{}},
+		compositeField{name: "color", typeName: "text", defaultVal: &pgtype.Text{}},
 	)
 }
 
@@ -218,8 +218,8 @@ func (tr *typeResolver) newListItem() pgtype.ValueTranscoder {
 func (tr *typeResolver) newListStats() pgtype.ValueTranscoder {
 	return tr.newCompositeValue(
 		"list_stats",
-		compositeField{"val1", "text", &pgtype.Text{}},
-		compositeField{"val2", "_int4", &pgtype.Int4Array{}},
+		compositeField{name: "val1", typeName: "text", defaultVal: &pgtype.Text{}},
+		compositeField{name: "val2", typeName: "_int4", defaultVal: &pgtype.Int4Array{}},
 	)
 }
 
@@ -314,7 +314,7 @@ type textPreferrer struct {
 func (t textPreferrer) PreferredParamFormat() int16 { return pgtype.TextFormatCode }
 
 func (t textPreferrer) NewTypeValue() pgtype.Value {
-	return textPreferrer{pgtype.NewValue(t.ValueTranscoder).(pgtype.ValueTranscoder), t.typeName}
+	return textPreferrer{ValueTranscoder: pgtype.NewValue(t.ValueTranscoder).(pgtype.ValueTranscoder), typeName: t.typeName}
 }
 
 func (t textPreferrer) TypeName() string {

--- a/example/go_pointer_types/query.sql.go
+++ b/example/go_pointer_types/query.sql.go
@@ -446,7 +446,7 @@ type textPreferrer struct {
 func (t textPreferrer) PreferredParamFormat() int16 { return pgtype.TextFormatCode }
 
 func (t textPreferrer) NewTypeValue() pgtype.Value {
-	return textPreferrer{pgtype.NewValue(t.ValueTranscoder).(pgtype.ValueTranscoder), t.typeName}
+	return textPreferrer{ValueTranscoder: pgtype.NewValue(t.ValueTranscoder).(pgtype.ValueTranscoder), typeName: t.typeName}
 }
 
 func (t textPreferrer) TypeName() string {

--- a/example/ltree/query.sql.go
+++ b/example/ltree/query.sql.go
@@ -347,7 +347,7 @@ type textPreferrer struct {
 func (t textPreferrer) PreferredParamFormat() int16 { return pgtype.TextFormatCode }
 
 func (t textPreferrer) NewTypeValue() pgtype.Value {
-	return textPreferrer{pgtype.NewValue(t.ValueTranscoder).(pgtype.ValueTranscoder), t.typeName}
+	return textPreferrer{ValueTranscoder: pgtype.NewValue(t.ValueTranscoder).(pgtype.ValueTranscoder), typeName: t.typeName}
 }
 
 func (t textPreferrer) TypeName() string {

--- a/example/numeric_external/query.sql.go
+++ b/example/numeric_external/query.sql.go
@@ -183,7 +183,7 @@ func (tr *typeResolver) newCompositeValue(name string, fields ...compositeField)
 	// names does not equal the number of ValueTranscoders.
 	typ, _ := pgtype.NewCompositeTypeValues(name, fs, vals)
 	if !isBinaryOk {
-		return textPreferrer{typ, name}
+		return textPreferrer{ValueTranscoder: typ, typeName: name}
 	}
 	return typ
 }
@@ -202,7 +202,7 @@ func (tr *typeResolver) newArrayValue(name, elemName string, defaultVal func() p
 	}
 	typ := pgtype.NewArrayType(name, elemOID, elemValFunc)
 	if elemOID == unknownOID {
-		return textPreferrer{typ, name}
+		return textPreferrer{ValueTranscoder: typ, typeName: name}
 	}
 	return typ
 }
@@ -212,7 +212,7 @@ func (tr *typeResolver) newArrayValue(name, elemName string, defaultVal func() p
 func (tr *typeResolver) newNumericExternalType() pgtype.ValueTranscoder {
 	return tr.newCompositeValue(
 		"numeric_external_type",
-		compositeField{"num", "numeric", &pgtype.Numeric{}},
+		compositeField{name: "num", typeName: "numeric", defaultVal: &pgtype.Numeric{}},
 	)
 }
 
@@ -355,7 +355,7 @@ type textPreferrer struct {
 func (t textPreferrer) PreferredParamFormat() int16 { return pgtype.TextFormatCode }
 
 func (t textPreferrer) NewTypeValue() pgtype.Value {
-	return textPreferrer{pgtype.NewValue(t.ValueTranscoder).(pgtype.ValueTranscoder), t.typeName}
+	return textPreferrer{ValueTranscoder: pgtype.NewValue(t.ValueTranscoder).(pgtype.ValueTranscoder), typeName: t.typeName}
 }
 
 func (t textPreferrer) TypeName() string {

--- a/example/pgcrypto/query.sql.go
+++ b/example/pgcrypto/query.sql.go
@@ -225,7 +225,7 @@ type textPreferrer struct {
 func (t textPreferrer) PreferredParamFormat() int16 { return pgtype.TextFormatCode }
 
 func (t textPreferrer) NewTypeValue() pgtype.Value {
-	return textPreferrer{pgtype.NewValue(t.ValueTranscoder).(pgtype.ValueTranscoder), t.typeName}
+	return textPreferrer{ValueTranscoder: pgtype.NewValue(t.ValueTranscoder).(pgtype.ValueTranscoder), typeName: t.typeName}
 }
 
 func (t textPreferrer) TypeName() string {

--- a/example/separate_out_dir/out/alpha_query.sql.0.go
+++ b/example/separate_out_dir/out/alpha_query.sql.0.go
@@ -202,7 +202,7 @@ func (tr *typeResolver) newCompositeValue(name string, fields ...compositeField)
 	// names does not equal the number of ValueTranscoders.
 	typ, _ := pgtype.NewCompositeTypeValues(name, fs, vals)
 	if !isBinaryOk {
-		return textPreferrer{typ, name}
+		return textPreferrer{ValueTranscoder: typ, typeName: name}
 	}
 	return typ
 }
@@ -221,7 +221,7 @@ func (tr *typeResolver) newArrayValue(name, elemName string, defaultVal func() p
 	}
 	typ := pgtype.NewArrayType(name, elemOID, elemValFunc)
 	if elemOID == unknownOID {
-		return textPreferrer{typ, name}
+		return textPreferrer{ValueTranscoder: typ, typeName: name}
 	}
 	return typ
 }
@@ -231,7 +231,7 @@ func (tr *typeResolver) newArrayValue(name, elemName string, defaultVal func() p
 func (tr *typeResolver) newAlpha() pgtype.ValueTranscoder {
 	return tr.newCompositeValue(
 		"alpha",
-		compositeField{"key", "text", &pgtype.Text{}},
+		compositeField{name: "key", typeName: "text", defaultVal: &pgtype.Text{}},
 	)
 }
 
@@ -319,7 +319,7 @@ type textPreferrer struct {
 func (t textPreferrer) PreferredParamFormat() int16 { return pgtype.TextFormatCode }
 
 func (t textPreferrer) NewTypeValue() pgtype.Value {
-	return textPreferrer{pgtype.NewValue(t.ValueTranscoder).(pgtype.ValueTranscoder), t.typeName}
+	return textPreferrer{ValueTranscoder: pgtype.NewValue(t.ValueTranscoder).(pgtype.ValueTranscoder), typeName: t.typeName}
 }
 
 func (t textPreferrer) TypeName() string {

--- a/example/slices/query.sql.go
+++ b/example/slices/query.sql.go
@@ -198,7 +198,7 @@ func (tr *typeResolver) newCompositeValue(name string, fields ...compositeField)
 	// names does not equal the number of ValueTranscoders.
 	typ, _ := pgtype.NewCompositeTypeValues(name, fs, vals)
 	if !isBinaryOk {
-		return textPreferrer{typ, name}
+		return textPreferrer{ValueTranscoder: typ, typeName: name}
 	}
 	return typ
 }
@@ -217,7 +217,7 @@ func (tr *typeResolver) newArrayValue(name, elemName string, defaultVal func() p
 	}
 	typ := pgtype.NewArrayType(name, elemOID, elemValFunc)
 	if elemOID == unknownOID {
-		return textPreferrer{typ, name}
+		return textPreferrer{ValueTranscoder: typ, typeName: name}
 	}
 	return typ
 }
@@ -404,7 +404,7 @@ type textPreferrer struct {
 func (t textPreferrer) PreferredParamFormat() int16 { return pgtype.TextFormatCode }
 
 func (t textPreferrer) NewTypeValue() pgtype.Value {
-	return textPreferrer{pgtype.NewValue(t.ValueTranscoder).(pgtype.ValueTranscoder), t.typeName}
+	return textPreferrer{ValueTranscoder: pgtype.NewValue(t.ValueTranscoder).(pgtype.ValueTranscoder), typeName: t.typeName}
 }
 
 func (t textPreferrer) TypeName() string {

--- a/example/syntax/query.sql.go
+++ b/example/syntax/query.sql.go
@@ -511,7 +511,7 @@ type textPreferrer struct {
 func (t textPreferrer) PreferredParamFormat() int16 { return pgtype.TextFormatCode }
 
 func (t textPreferrer) NewTypeValue() pgtype.Value {
-	return textPreferrer{pgtype.NewValue(t.ValueTranscoder).(pgtype.ValueTranscoder), t.typeName}
+	return textPreferrer{ValueTranscoder: pgtype.NewValue(t.ValueTranscoder).(pgtype.ValueTranscoder), typeName: t.typeName}
 }
 
 func (t textPreferrer) TypeName() string {

--- a/example/void/query.sql.go
+++ b/example/void/query.sql.go
@@ -357,7 +357,7 @@ type textPreferrer struct {
 func (t textPreferrer) PreferredParamFormat() int16 { return pgtype.TextFormatCode }
 
 func (t textPreferrer) NewTypeValue() pgtype.Value {
-	return textPreferrer{pgtype.NewValue(t.ValueTranscoder).(pgtype.ValueTranscoder), t.typeName}
+	return textPreferrer{ValueTranscoder: pgtype.NewValue(t.ValueTranscoder).(pgtype.ValueTranscoder), typeName: t.typeName}
 }
 
 func (t textPreferrer) TypeName() string {

--- a/internal/codegen/golang/declarer.go
+++ b/internal/codegen/golang/declarer.go
@@ -224,7 +224,7 @@ func (tr *typeResolver) newCompositeValue(name string, fields ...compositeField)
 	// names does not equal the number of ValueTranscoders.
 	typ, _ := pgtype.NewCompositeTypeValues(name, fs, vals)
 	if !isBinaryOk {
-		return textPreferrer{typ, name}
+		return textPreferrer{ValueTranscoder: typ, typeName: name}
 	}
 	return typ
 }
@@ -243,7 +243,7 @@ func (tr *typeResolver) newArrayValue(name, elemName string, defaultVal func() p
 	}
 	typ := pgtype.NewArrayType(name, elemOID, elemValFunc)
 	if elemOID == unknownOID {
-		return textPreferrer{typ, name}
+		return textPreferrer{ValueTranscoder: typ, typeName: name}
 	}
 	return typ
 }`

--- a/internal/codegen/golang/declarer_composite.go
+++ b/internal/codegen/golang/declarer_composite.go
@@ -146,11 +146,11 @@ func (c CompositeTranscoderDeclarer) Declare(pkgPath string) (string, error) {
 	// newCompositeValue - field names of the composite type
 	for i := range c.typ.FieldNames {
 		sb.WriteString("\n\t\t")
-		sb.WriteString(`compositeField{`)
+		sb.WriteString(`compositeField{name: `)
 		sb.WriteString(strconv.Quote(c.typ.PgComposite.ColumnNames[i])) // field name
-		sb.WriteString(", ")
+		sb.WriteString(", typeName: ")
 		sb.WriteString(strconv.Quote(c.typ.PgComposite.ColumnTypes[i].String())) // field type name
-		sb.WriteString(", ")
+		sb.WriteString(", defaultVal: ")
 
 		// field default pgtype.ValueTranscoder
 		switch fieldType := gotype.UnwrapNestedType(c.typ.FieldTypes[i]).(type) {

--- a/internal/codegen/golang/query.gotemplate
+++ b/internal/codegen/golang/query.gotemplate
@@ -229,7 +229,7 @@ type textPreferrer struct {
 func (t textPreferrer) PreferredParamFormat() int16 { return pgtype.TextFormatCode }
 
 func (t textPreferrer) NewTypeValue() pgtype.Value {
-	return textPreferrer{pgtype.NewValue(t.ValueTranscoder).(pgtype.ValueTranscoder), t.typeName}
+	return textPreferrer{ValueTranscoder: pgtype.NewValue(t.ValueTranscoder).(pgtype.ValueTranscoder), typeName: t.typeName}
 }
 
 func (t textPreferrer) TypeName() string {

--- a/internal/codegen/golang/testdata/declarer_composite.input.golden
+++ b/internal/codegen/golang/testdata/declarer_composite.input.golden
@@ -66,7 +66,7 @@ func (tr *typeResolver) newCompositeValue(name string, fields ...compositeField)
 	// names does not equal the number of ValueTranscoders.
 	typ, _ := pgtype.NewCompositeTypeValues(name, fs, vals)
 	if !isBinaryOk {
-		return textPreferrer{typ, name}
+		return textPreferrer{ValueTranscoder: typ, typeName: name}
 	}
 	return typ
 }
@@ -85,7 +85,7 @@ func (tr *typeResolver) newArrayValue(name, elemName string, defaultVal func() p
 	}
 	typ := pgtype.NewArrayType(name, elemOID, elemValFunc)
 	if elemOID == unknownOID {
-		return textPreferrer{typ, name}
+		return textPreferrer{ValueTranscoder: typ, typeName: name}
 	}
 	return typ
 }
@@ -95,8 +95,8 @@ func (tr *typeResolver) newArrayValue(name, elemName string, defaultVal func() p
 func (tr *typeResolver) newSomeTable() pgtype.ValueTranscoder {
 	return tr.newCompositeValue(
 		"some_table",
-		compositeField{"foo", "int2", &pgtype.Int2{}},
-		compositeField{"bar_baz", "text", &pgtype.Text{}},
+		compositeField{name: "foo", typeName: "int2", defaultVal: &pgtype.Int2{}},
+		compositeField{name: "bar_baz", typeName: "text", defaultVal: &pgtype.Text{}},
 	)
 }
 

--- a/internal/codegen/golang/testdata/declarer_composite.output.golden
+++ b/internal/codegen/golang/testdata/declarer_composite.output.golden
@@ -66,7 +66,7 @@ func (tr *typeResolver) newCompositeValue(name string, fields ...compositeField)
 	// names does not equal the number of ValueTranscoders.
 	typ, _ := pgtype.NewCompositeTypeValues(name, fs, vals)
 	if !isBinaryOk {
-		return textPreferrer{typ, name}
+		return textPreferrer{ValueTranscoder: typ, typeName: name}
 	}
 	return typ
 }
@@ -85,7 +85,7 @@ func (tr *typeResolver) newArrayValue(name, elemName string, defaultVal func() p
 	}
 	typ := pgtype.NewArrayType(name, elemOID, elemValFunc)
 	if elemOID == unknownOID {
-		return textPreferrer{typ, name}
+		return textPreferrer{ValueTranscoder: typ, typeName: name}
 	}
 	return typ
 }
@@ -95,7 +95,7 @@ func (tr *typeResolver) newArrayValue(name, elemName string, defaultVal func() p
 func (tr *typeResolver) newSomeTable() pgtype.ValueTranscoder {
 	return tr.newCompositeValue(
 		"some_table",
-		compositeField{"foo", "int2", &pgtype.Int2{}},
-		compositeField{"bar_baz", "text", &pgtype.Text{}},
+		compositeField{name: "foo", typeName: "int2", defaultVal: &pgtype.Int2{}},
+		compositeField{name: "bar_baz", typeName: "text", defaultVal: &pgtype.Text{}},
 	)
 }

--- a/internal/codegen/golang/testdata/declarer_composite_array.input.golden
+++ b/internal/codegen/golang/testdata/declarer_composite_array.input.golden
@@ -66,7 +66,7 @@ func (tr *typeResolver) newCompositeValue(name string, fields ...compositeField)
 	// names does not equal the number of ValueTranscoders.
 	typ, _ := pgtype.NewCompositeTypeValues(name, fs, vals)
 	if !isBinaryOk {
-		return textPreferrer{typ, name}
+		return textPreferrer{ValueTranscoder: typ, typeName: name}
 	}
 	return typ
 }
@@ -85,7 +85,7 @@ func (tr *typeResolver) newArrayValue(name, elemName string, defaultVal func() p
 	}
 	typ := pgtype.NewArrayType(name, elemOID, elemValFunc)
 	if elemOID == unknownOID {
-		return textPreferrer{typ, name}
+		return textPreferrer{ValueTranscoder: typ, typeName: name}
 	}
 	return typ
 }
@@ -95,8 +95,8 @@ func (tr *typeResolver) newArrayValue(name, elemName string, defaultVal func() p
 func (tr *typeResolver) newSomeTable() pgtype.ValueTranscoder {
 	return tr.newCompositeValue(
 		"some_table",
-		compositeField{"foo", "int2", &pgtype.Int2{}},
-		compositeField{"bar_baz", "text", &pgtype.Text{}},
+		compositeField{name: "foo", typeName: "int2", defaultVal: &pgtype.Int2{}},
+		compositeField{name: "bar_baz", typeName: "text", defaultVal: &pgtype.Text{}},
 	)
 }
 

--- a/internal/codegen/golang/testdata/declarer_composite_array.output.golden
+++ b/internal/codegen/golang/testdata/declarer_composite_array.output.golden
@@ -66,7 +66,7 @@ func (tr *typeResolver) newCompositeValue(name string, fields ...compositeField)
 	// names does not equal the number of ValueTranscoders.
 	typ, _ := pgtype.NewCompositeTypeValues(name, fs, vals)
 	if !isBinaryOk {
-		return textPreferrer{typ, name}
+		return textPreferrer{ValueTranscoder: typ, typeName: name}
 	}
 	return typ
 }
@@ -85,7 +85,7 @@ func (tr *typeResolver) newArrayValue(name, elemName string, defaultVal func() p
 	}
 	typ := pgtype.NewArrayType(name, elemOID, elemValFunc)
 	if elemOID == unknownOID {
-		return textPreferrer{typ, name}
+		return textPreferrer{ValueTranscoder: typ, typeName: name}
 	}
 	return typ
 }
@@ -95,8 +95,8 @@ func (tr *typeResolver) newArrayValue(name, elemName string, defaultVal func() p
 func (tr *typeResolver) newSomeTable() pgtype.ValueTranscoder {
 	return tr.newCompositeValue(
 		"some_table",
-		compositeField{"foo", "int2", &pgtype.Int2{}},
-		compositeField{"bar_baz", "text", &pgtype.Text{}},
+		compositeField{name: "foo", typeName: "int2", defaultVal: &pgtype.Int2{}},
+		compositeField{name: "bar_baz", typeName: "text", defaultVal: &pgtype.Text{}},
 	)
 }
 

--- a/internal/codegen/golang/testdata/declarer_composite_enum.input.golden
+++ b/internal/codegen/golang/testdata/declarer_composite_enum.input.golden
@@ -87,7 +87,7 @@ func (tr *typeResolver) newCompositeValue(name string, fields ...compositeField)
 	// names does not equal the number of ValueTranscoders.
 	typ, _ := pgtype.NewCompositeTypeValues(name, fs, vals)
 	if !isBinaryOk {
-		return textPreferrer{typ, name}
+		return textPreferrer{ValueTranscoder: typ, typeName: name}
 	}
 	return typ
 }
@@ -106,7 +106,7 @@ func (tr *typeResolver) newArrayValue(name, elemName string, defaultVal func() p
 	}
 	typ := pgtype.NewArrayType(name, elemOID, elemValFunc)
 	if elemOID == unknownOID {
-		return textPreferrer{typ, name}
+		return textPreferrer{ValueTranscoder: typ, typeName: name}
 	}
 	return typ
 }
@@ -116,7 +116,7 @@ func (tr *typeResolver) newArrayValue(name, elemName string, defaultVal func() p
 func (tr *typeResolver) newSomeTableEnum() pgtype.ValueTranscoder {
 	return tr.newCompositeValue(
 		"some_table_enum",
-		compositeField{"foo", "some_table_enum", newDeviceTypeEnum()},
+		compositeField{name: "foo", typeName: "some_table_enum", defaultVal: newDeviceTypeEnum()},
 	)
 }
 

--- a/internal/codegen/golang/testdata/declarer_composite_enum.output.golden
+++ b/internal/codegen/golang/testdata/declarer_composite_enum.output.golden
@@ -87,7 +87,7 @@ func (tr *typeResolver) newCompositeValue(name string, fields ...compositeField)
 	// names does not equal the number of ValueTranscoders.
 	typ, _ := pgtype.NewCompositeTypeValues(name, fs, vals)
 	if !isBinaryOk {
-		return textPreferrer{typ, name}
+		return textPreferrer{ValueTranscoder: typ, typeName: name}
 	}
 	return typ
 }
@@ -106,7 +106,7 @@ func (tr *typeResolver) newArrayValue(name, elemName string, defaultVal func() p
 	}
 	typ := pgtype.NewArrayType(name, elemOID, elemValFunc)
 	if elemOID == unknownOID {
-		return textPreferrer{typ, name}
+		return textPreferrer{ValueTranscoder: typ, typeName: name}
 	}
 	return typ
 }
@@ -116,6 +116,6 @@ func (tr *typeResolver) newArrayValue(name, elemName string, defaultVal func() p
 func (tr *typeResolver) newSomeTableEnum() pgtype.ValueTranscoder {
 	return tr.newCompositeValue(
 		"some_table_enum",
-		compositeField{"foo", "some_table_enum", newDeviceTypeEnum()},
+		compositeField{name: "foo", typeName: "some_table_enum", defaultVal: newDeviceTypeEnum()},
 	)
 }

--- a/internal/codegen/golang/testdata/declarer_composite_nested.input.golden
+++ b/internal/codegen/golang/testdata/declarer_composite_nested.input.golden
@@ -71,7 +71,7 @@ func (tr *typeResolver) newCompositeValue(name string, fields ...compositeField)
 	// names does not equal the number of ValueTranscoders.
 	typ, _ := pgtype.NewCompositeTypeValues(name, fs, vals)
 	if !isBinaryOk {
-		return textPreferrer{typ, name}
+		return textPreferrer{ValueTranscoder: typ, typeName: name}
 	}
 	return typ
 }
@@ -90,7 +90,7 @@ func (tr *typeResolver) newArrayValue(name, elemName string, defaultVal func() p
 	}
 	typ := pgtype.NewArrayType(name, elemOID, elemValFunc)
 	if elemOID == unknownOID {
-		return textPreferrer{typ, name}
+		return textPreferrer{ValueTranscoder: typ, typeName: name}
 	}
 	return typ
 }
@@ -100,7 +100,7 @@ func (tr *typeResolver) newArrayValue(name, elemName string, defaultVal func() p
 func (tr *typeResolver) newFooType() pgtype.ValueTranscoder {
 	return tr.newCompositeValue(
 		"foo_type",
-		compositeField{"alpha", "text", &pgtype.Text{}},
+		compositeField{name: "alpha", typeName: "text", defaultVal: &pgtype.Text{}},
 	)
 }
 
@@ -117,8 +117,8 @@ func (tr *typeResolver) newFooTypeRaw(v FooType) []interface{} {
 func (tr *typeResolver) newSomeTableNested() pgtype.ValueTranscoder {
 	return tr.newCompositeValue(
 		"some_table_nested",
-		compositeField{"foo", "foo_type", tr.newFooType()},
-		compositeField{"bar_baz", "text", &pgtype.Text{}},
+		compositeField{name: "foo", typeName: "foo_type", defaultVal: tr.newFooType()},
+		compositeField{name: "bar_baz", typeName: "text", defaultVal: &pgtype.Text{}},
 	)
 }
 

--- a/internal/codegen/golang/testdata/declarer_composite_nested.output.golden
+++ b/internal/codegen/golang/testdata/declarer_composite_nested.output.golden
@@ -71,7 +71,7 @@ func (tr *typeResolver) newCompositeValue(name string, fields ...compositeField)
 	// names does not equal the number of ValueTranscoders.
 	typ, _ := pgtype.NewCompositeTypeValues(name, fs, vals)
 	if !isBinaryOk {
-		return textPreferrer{typ, name}
+		return textPreferrer{ValueTranscoder: typ, typeName: name}
 	}
 	return typ
 }
@@ -90,7 +90,7 @@ func (tr *typeResolver) newArrayValue(name, elemName string, defaultVal func() p
 	}
 	typ := pgtype.NewArrayType(name, elemOID, elemValFunc)
 	if elemOID == unknownOID {
-		return textPreferrer{typ, name}
+		return textPreferrer{ValueTranscoder: typ, typeName: name}
 	}
 	return typ
 }
@@ -100,7 +100,7 @@ func (tr *typeResolver) newArrayValue(name, elemName string, defaultVal func() p
 func (tr *typeResolver) newFooType() pgtype.ValueTranscoder {
 	return tr.newCompositeValue(
 		"foo_type",
-		compositeField{"alpha", "text", &pgtype.Text{}},
+		compositeField{name: "alpha", typeName: "text", defaultVal: &pgtype.Text{}},
 	)
 }
 
@@ -109,7 +109,7 @@ func (tr *typeResolver) newFooType() pgtype.ValueTranscoder {
 func (tr *typeResolver) newSomeTableNested() pgtype.ValueTranscoder {
 	return tr.newCompositeValue(
 		"some_table_nested",
-		compositeField{"foo", "foo_type", tr.newFooType()},
-		compositeField{"bar_baz", "text", &pgtype.Text{}},
+		compositeField{name: "foo", typeName: "foo_type", defaultVal: tr.newFooType()},
+		compositeField{name: "bar_baz", typeName: "text", defaultVal: &pgtype.Text{}},
 	)
 }

--- a/internal/pg/query.sql.go
+++ b/internal/pg/query.sql.go
@@ -690,7 +690,7 @@ type textPreferrer struct {
 func (t textPreferrer) PreferredParamFormat() int16 { return pgtype.TextFormatCode }
 
 func (t textPreferrer) NewTypeValue() pgtype.Value {
-	return textPreferrer{pgtype.NewValue(t.ValueTranscoder).(pgtype.ValueTranscoder), t.typeName}
+	return textPreferrer{ValueTranscoder: pgtype.NewValue(t.ValueTranscoder).(pgtype.ValueTranscoder), typeName: t.typeName}
 }
 
 func (t textPreferrer) TypeName() string {


### PR DESCRIPTION
Adds the field names when instantiating the `compositeField` and
`textPreferrer` struct in the generated code.

This allows to run the [fieldalignment](https://pkg.go.dev/golang.org/x/tools/go/analysis/passes/fieldalignment) linter without errors on the generated code.