### PR TITLE
refactor: remove deprecated ioutil

### DIFF
--- a/example/author/codegen_test.go
+++ b/example/author/codegen_test.go
@@ -4,7 +4,7 @@ import (
 	"github.com/jschaf/pggen"
 	"github.com/jschaf/pggen/internal/pgtest"
 	"github.com/stretchr/testify/assert"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 )
@@ -30,11 +30,11 @@ func TestGenerate_Go_Example_Author(t *testing.T) {
 	gotQueriesFile := filepath.Join(tmpDir, "query.sql.go")
 	assert.FileExists(t, gotQueriesFile,
 		"Generate() should emit query.sql.go")
-	wantQueries, err := ioutil.ReadFile(wantQueriesFile)
+	wantQueries, err := os.ReadFile(wantQueriesFile)
 	if err != nil {
 		t.Fatalf("read wanted query.go.sql: %s", err)
 	}
-	gotQueries, err := ioutil.ReadFile(gotQueriesFile)
+	gotQueries, err := os.ReadFile(gotQueriesFile)
 	if err != nil {
 		t.Fatalf("read generated query.go.sql: %s", err)
 	}

--- a/example/complex_params/codegen_test.go
+++ b/example/complex_params/codegen_test.go
@@ -4,7 +4,7 @@ import (
 	"github.com/jschaf/pggen"
 	"github.com/jschaf/pggen/internal/pgtest"
 	"github.com/stretchr/testify/assert"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 )
@@ -33,11 +33,11 @@ func TestGenerate_Go_Example_ComplexParams(t *testing.T) {
 	wantQueriesFile := "query.sql.go"
 	gotQueriesFile := filepath.Join(tmpDir, "query.sql.go")
 	assert.FileExists(t, gotQueriesFile, "Generate() should emit query.sql.go")
-	wantQueries, err := ioutil.ReadFile(wantQueriesFile)
+	wantQueries, err := os.ReadFile(wantQueriesFile)
 	if err != nil {
 		t.Fatalf("read wanted query.go.sql: %s", err)
 	}
-	gotQueries, err := ioutil.ReadFile(gotQueriesFile)
+	gotQueries, err := os.ReadFile(gotQueriesFile)
 	if err != nil {
 		t.Fatalf("read generated query.go.sql: %s", err)
 	}

--- a/example/composite/codegen_test.go
+++ b/example/composite/codegen_test.go
@@ -4,7 +4,7 @@ import (
 	"github.com/jschaf/pggen"
 	"github.com/jschaf/pggen/internal/pgtest"
 	"github.com/stretchr/testify/assert"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 )
@@ -38,11 +38,11 @@ func TestGenerate_Go_Example_Composite(t *testing.T) {
 	gotQueriesFile := filepath.Join(tmpDir, "query.sql.go")
 	assert.FileExists(t, gotQueriesFile,
 		"Generate() should emit query.sql.go")
-	wantQueries, err := ioutil.ReadFile(wantQueriesFile)
+	wantQueries, err := os.ReadFile(wantQueriesFile)
 	if err != nil {
 		t.Fatalf("read wanted query.go.sql: %s", err)
 	}
-	gotQueries, err := ioutil.ReadFile(gotQueriesFile)
+	gotQueries, err := os.ReadFile(gotQueriesFile)
 	if err != nil {
 		t.Fatalf("read generated query.go.sql: %s", err)
 	}

--- a/example/custom_types/codegen_test.go
+++ b/example/custom_types/codegen_test.go
@@ -4,7 +4,7 @@ import (
 	"github.com/jschaf/pggen"
 	"github.com/jschaf/pggen/internal/pgtest"
 	"github.com/stretchr/testify/assert"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 )
@@ -35,11 +35,11 @@ func TestGenerate_Go_Example_CustomTypes(t *testing.T) {
 	wantQueriesFile := "query.sql.go"
 	gotQueriesFile := filepath.Join(tmpDir, "query.sql.go")
 	assert.FileExists(t, gotQueriesFile, "Generate() should emit query.sql.go")
-	wantQueries, err := ioutil.ReadFile(wantQueriesFile)
+	wantQueries, err := os.ReadFile(wantQueriesFile)
 	if err != nil {
 		t.Fatalf("read wanted query.go.sql: %s", err)
 	}
-	gotQueries, err := ioutil.ReadFile(gotQueriesFile)
+	gotQueries, err := os.ReadFile(gotQueriesFile)
 	if err != nil {
 		t.Fatalf("read generated query.go.sql: %s", err)
 	}

--- a/example/device/codegen_test.go
+++ b/example/device/codegen_test.go
@@ -4,7 +4,7 @@ import (
 	"github.com/jschaf/pggen"
 	"github.com/jschaf/pggen/internal/pgtest"
 	"github.com/stretchr/testify/assert"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 )
@@ -29,11 +29,11 @@ func TestGenerate_Go_Example_Device(t *testing.T) {
 	wantQueriesFile := "query.sql.go"
 	gotQueriesFile := filepath.Join(tmpDir, "query.sql.go")
 	assert.FileExists(t, gotQueriesFile, "Generate() should emit query.sql.go")
-	wantQueries, err := ioutil.ReadFile(wantQueriesFile)
+	wantQueries, err := os.ReadFile(wantQueriesFile)
 	if err != nil {
 		t.Fatalf("read wanted query.go.sql: %s", err)
 	}
-	gotQueries, err := ioutil.ReadFile(gotQueriesFile)
+	gotQueries, err := os.ReadFile(gotQueriesFile)
 	if err != nil {
 		t.Fatalf("read generated query.go.sql: %s", err)
 	}

--- a/example/domain/codegen_test.go
+++ b/example/domain/codegen_test.go
@@ -4,7 +4,7 @@ import (
 	"github.com/jschaf/pggen"
 	"github.com/jschaf/pggen/internal/pgtest"
 	"github.com/stretchr/testify/assert"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 )
@@ -29,11 +29,11 @@ func TestGenerate_Go_Example_Domain(t *testing.T) {
 	wantQueriesFile := "query.sql.go"
 	gotQueriesFile := filepath.Join(tmpDir, "query.sql.go")
 	assert.FileExists(t, gotQueriesFile, "Generate() should emit query.sql.go")
-	wantQueries, err := ioutil.ReadFile(wantQueriesFile)
+	wantQueries, err := os.ReadFile(wantQueriesFile)
 	if err != nil {
 		t.Fatalf("read wanted query.go.sql: %s", err)
 	}
-	gotQueries, err := ioutil.ReadFile(gotQueriesFile)
+	gotQueries, err := os.ReadFile(gotQueriesFile)
 	if err != nil {
 		t.Fatalf("read generated query.go.sql: %s", err)
 	}

--- a/example/enums/codegen_test.go
+++ b/example/enums/codegen_test.go
@@ -4,7 +4,7 @@ import (
 	"github.com/jschaf/pggen"
 	"github.com/jschaf/pggen/internal/pgtest"
 	"github.com/stretchr/testify/assert"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 )
@@ -29,11 +29,11 @@ func TestGenerate_Go_Example_Enums(t *testing.T) {
 	wantQueriesFile := "query.sql.go"
 	gotQueriesFile := filepath.Join(tmpDir, "query.sql.go")
 	assert.FileExists(t, gotQueriesFile, "Generate() should emit query.sql.go")
-	wantQueries, err := ioutil.ReadFile(wantQueriesFile)
+	wantQueries, err := os.ReadFile(wantQueriesFile)
 	if err != nil {
 		t.Fatalf("read wanted query.go.sql: %s", err)
 	}
-	gotQueries, err := ioutil.ReadFile(gotQueriesFile)
+	gotQueries, err := os.ReadFile(gotQueriesFile)
 	if err != nil {
 		t.Fatalf("read generated query.go.sql: %s", err)
 	}

--- a/example/erp/order/codegen_test.go
+++ b/example/erp/order/codegen_test.go
@@ -4,7 +4,7 @@ import (
 	"github.com/jschaf/pggen"
 	"github.com/jschaf/pggen/internal/pgtest"
 	"github.com/stretchr/testify/assert"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 )
@@ -35,14 +35,14 @@ func TestGenerate_Go_Example_Order(t *testing.T) {
 	}
 
 	for _, file := range []string{"customer.sql.go", "price.sql.go"} {
-		wantQueries, err := ioutil.ReadFile(file)
+		wantQueries, err := os.ReadFile(file)
 		if err != nil {
 			t.Fatalf("read wanted file %s: %s", file, err)
 		}
 
 		gotFile := filepath.Join(tmpDir, file)
 		assert.FileExists(t, gotFile, "Generate() should emit "+file)
-		gotQueries, err := ioutil.ReadFile(gotFile)
+		gotQueries, err := os.ReadFile(gotFile)
 		if err != nil {
 			t.Fatalf("read generated %s: %s", file, err)
 		}

--- a/example/function/codegen_test.go
+++ b/example/function/codegen_test.go
@@ -4,7 +4,7 @@ import (
 	"github.com/jschaf/pggen"
 	"github.com/jschaf/pggen/internal/pgtest"
 	"github.com/stretchr/testify/assert"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 )
@@ -30,11 +30,11 @@ func TestGenerate_Go_Example_Function(t *testing.T) {
 	gotQueriesFile := filepath.Join(tmpDir, "query.sql.go")
 	assert.FileExists(t, gotQueriesFile,
 		"Generate() should emit query.sql.go")
-	wantQueries, err := ioutil.ReadFile(wantQueriesFile)
+	wantQueries, err := os.ReadFile(wantQueriesFile)
 	if err != nil {
 		t.Fatalf("read wanted query.go.sql: %s", err)
 	}
-	gotQueries, err := ioutil.ReadFile(gotQueriesFile)
+	gotQueries, err := os.ReadFile(gotQueriesFile)
 	if err != nil {
 		t.Fatalf("read generated query.go.sql: %s", err)
 	}

--- a/example/go_pointer_types/codegen_test.go
+++ b/example/go_pointer_types/codegen_test.go
@@ -4,7 +4,7 @@ import (
 	"github.com/jschaf/pggen"
 	"github.com/jschaf/pggen/internal/pgtest"
 	"github.com/stretchr/testify/assert"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 )
@@ -36,11 +36,11 @@ func TestGenerate_Go_Example_GoPointerTypes(t *testing.T) {
 	wantQueriesFile := "query.sql.go"
 	gotQueriesFile := filepath.Join(tmpDir, "query.sql.go")
 	assert.FileExists(t, gotQueriesFile, "Generate() should emit query.sql.go")
-	wantQueries, err := ioutil.ReadFile(wantQueriesFile)
+	wantQueries, err := os.ReadFile(wantQueriesFile)
 	if err != nil {
 		t.Fatalf("read wanted query.go.sql: %s", err)
 	}
-	gotQueries, err := ioutil.ReadFile(gotQueriesFile)
+	gotQueries, err := os.ReadFile(gotQueriesFile)
 	if err != nil {
 		t.Fatalf("read generated query.go.sql: %s", err)
 	}

--- a/example/ltree/codegen_test.go
+++ b/example/ltree/codegen_test.go
@@ -4,7 +4,7 @@ import (
 	"github.com/jschaf/pggen"
 	"github.com/jschaf/pggen/internal/pgtest"
 	"github.com/stretchr/testify/assert"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 )
@@ -33,11 +33,11 @@ func TestGenerate_Go_Example_ltree(t *testing.T) {
 	wantQueriesFile := "query.sql.go"
 	gotQueriesFile := filepath.Join(tmpDir, "query.sql.go")
 	assert.FileExists(t, gotQueriesFile, "Generate() should emit query.sql.go")
-	wantQueries, err := ioutil.ReadFile(wantQueriesFile)
+	wantQueries, err := os.ReadFile(wantQueriesFile)
 	if err != nil {
 		t.Fatalf("read wanted query.go.sql: %s", err)
 	}
-	gotQueries, err := ioutil.ReadFile(gotQueriesFile)
+	gotQueries, err := os.ReadFile(gotQueriesFile)
 	if err != nil {
 		t.Fatalf("read generated query.go.sql: %s", err)
 	}

--- a/example/nested/codegen_test.go
+++ b/example/nested/codegen_test.go
@@ -4,7 +4,7 @@ import (
 	"github.com/jschaf/pggen"
 	"github.com/jschaf/pggen/internal/pgtest"
 	"github.com/stretchr/testify/assert"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 )
@@ -33,11 +33,11 @@ func TestGenerate_Go_Example_nested(t *testing.T) {
 	wantQueriesFile := "query.sql.go"
 	gotQueriesFile := filepath.Join(tmpDir, "query.sql.go")
 	assert.FileExists(t, gotQueriesFile, "Generate() should emit query.sql.go")
-	wantQueries, err := ioutil.ReadFile(wantQueriesFile)
+	wantQueries, err := os.ReadFile(wantQueriesFile)
 	if err != nil {
 		t.Fatalf("read wanted query.go.sql: %s", err)
 	}
-	gotQueries, err := ioutil.ReadFile(gotQueriesFile)
+	gotQueries, err := os.ReadFile(gotQueriesFile)
 	if err != nil {
 		t.Fatalf("read generated query.go.sql: %s", err)
 	}

--- a/example/numeric_external/codegen_test.go
+++ b/example/numeric_external/codegen_test.go
@@ -4,7 +4,7 @@ import (
 	"github.com/jschaf/pggen"
 	"github.com/jschaf/pggen/internal/pgtest"
 	"github.com/stretchr/testify/assert"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 )
@@ -36,11 +36,11 @@ func TestGenerate_Go_Example_Numeric_External(t *testing.T) {
 	gotQueriesFile := filepath.Join(tmpDir, "query.sql.go")
 	assert.FileExists(t, gotQueriesFile,
 		"Generate() should emit query.sql.go")
-	wantQueries, err := ioutil.ReadFile(wantQueriesFile)
+	wantQueries, err := os.ReadFile(wantQueriesFile)
 	if err != nil {
 		t.Fatalf("read wanted query.go.sql: %s", err)
 	}
-	gotQueries, err := ioutil.ReadFile(gotQueriesFile)
+	gotQueries, err := os.ReadFile(gotQueriesFile)
 	if err != nil {
 		t.Fatalf("read generated query.go.sql: %s", err)
 	}

--- a/example/pgcrypto/codegen_test.go
+++ b/example/pgcrypto/codegen_test.go
@@ -4,7 +4,7 @@ import (
 	"github.com/jschaf/pggen"
 	"github.com/jschaf/pggen/internal/pgtest"
 	"github.com/stretchr/testify/assert"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 )
@@ -29,11 +29,11 @@ func TestGenerate_Go_Example_Pgcrypto(t *testing.T) {
 	wantQueriesFile := "query.sql.go"
 	gotQueriesFile := filepath.Join(tmpDir, "query.sql.go")
 	assert.FileExists(t, gotQueriesFile, "Generate() should emit query.sql.go")
-	wantQueries, err := ioutil.ReadFile(wantQueriesFile)
+	wantQueries, err := os.ReadFile(wantQueriesFile)
 	if err != nil {
 		t.Fatalf("read wanted query.go.sql: %s", err)
 	}
-	gotQueries, err := ioutil.ReadFile(gotQueriesFile)
+	gotQueries, err := os.ReadFile(gotQueriesFile)
 	if err != nil {
 		t.Fatalf("read generated query.go.sql: %s", err)
 	}

--- a/example/separate_out_dir/out/codegen_test.go
+++ b/example/separate_out_dir/out/codegen_test.go
@@ -4,7 +4,7 @@ import (
 	"github.com/jschaf/pggen"
 	"github.com/jschaf/pggen/internal/pgtest"
 	"github.com/stretchr/testify/assert"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 )
@@ -37,14 +37,14 @@ func TestGenerate_Go_Example_SeparateOutDir(t *testing.T) {
 		"alpha_query.sql.1.go",
 		"bravo_query.sql.go",
 	} {
-		wantQueries, err := ioutil.ReadFile(file)
+		wantQueries, err := os.ReadFile(file)
 		if err != nil {
 			t.Fatalf("read wanted file %s: %s", file, err)
 		}
 
 		gotFile := filepath.Join(tmpDir, file)
 		assert.FileExists(t, gotFile, "Generate() should emit "+file)
-		gotQueries, err := ioutil.ReadFile(gotFile)
+		gotQueries, err := os.ReadFile(gotFile)
 		if err != nil {
 			t.Fatalf("read generated %s: %s", file, err)
 		}

--- a/example/syntax/codegen_test.go
+++ b/example/syntax/codegen_test.go
@@ -4,7 +4,7 @@ import (
 	"github.com/jschaf/pggen"
 	"github.com/jschaf/pggen/internal/pgtest"
 	"github.com/stretchr/testify/assert"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 )
@@ -31,11 +31,11 @@ func TestGenerate_Go_Example_Syntax(t *testing.T) {
 	wantQueriesFile := "query.sql.go"
 	gotQueriesFile := filepath.Join(tmpDir, "query.sql.go")
 	assert.FileExists(t, gotQueriesFile, "Generate() should emit query.sql.go")
-	wantQueries, err := ioutil.ReadFile(wantQueriesFile)
+	wantQueries, err := os.ReadFile(wantQueriesFile)
 	if err != nil {
 		t.Fatalf("read wanted query.go.sql: %s", err)
 	}
-	gotQueries, err := ioutil.ReadFile(gotQueriesFile)
+	gotQueries, err := os.ReadFile(gotQueriesFile)
 	if err != nil {
 		t.Fatalf("read generated query.go.sql: %s", err)
 	}

--- a/example/void/codegen_test.go
+++ b/example/void/codegen_test.go
@@ -4,7 +4,7 @@ import (
 	"github.com/jschaf/pggen"
 	"github.com/jschaf/pggen/internal/pgtest"
 	"github.com/stretchr/testify/assert"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 )
@@ -29,11 +29,11 @@ func TestGenerate_Go_Example_void(t *testing.T) {
 	wantQueriesFile := "query.sql.go"
 	gotQueriesFile := filepath.Join(tmpDir, "query.sql.go")
 	assert.FileExists(t, gotQueriesFile, "Generate() should emit query.sql.go")
-	wantQueries, err := ioutil.ReadFile(wantQueriesFile)
+	wantQueries, err := os.ReadFile(wantQueriesFile)
 	if err != nil {
 		t.Fatalf("read wanted query.go.sql: %s", err)
 	}
-	gotQueries, err := ioutil.ReadFile(gotQueriesFile)
+	gotQueries, err := os.ReadFile(gotQueriesFile)
 	if err != nil {
 		t.Fatalf("read generated query.go.sql: %s", err)
 	}

--- a/generate.go
+++ b/generate.go
@@ -16,7 +16,7 @@ import (
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	gotok "go/token"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"time"
 )
@@ -176,7 +176,7 @@ func connectPostgres(
 			return nil, nopErrEnricher, nopCleanup, fmt.Errorf("cannot run non-sql schema file on Postgres "+
 				"(*.sh and *.sql.gz files only supported without --postgres-connection): %s", script)
 		}
-		bs, err := ioutil.ReadFile(script)
+		bs, err := os.ReadFile(script)
 		if err != nil {
 			return nil, nil, nopCleanup, fmt.Errorf("read schema file: %w", err)
 		}

--- a/generate_test.go
+++ b/generate_test.go
@@ -4,7 +4,7 @@ import (
 	"github.com/jschaf/pggen/internal/pgtest"
 	"github.com/jschaf/pggen/internal/texts"
 	"github.com/stretchr/testify/assert"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 )
@@ -43,7 +43,7 @@ func TestGenerate_Golang_Error(t *testing.T) {
 			defer cleanupFunc()
 			tmpDir := t.TempDir()
 			queryFile := filepath.Join(tmpDir, "query.sql")
-			err := ioutil.WriteFile(queryFile, []byte(tt.queries), 0644)
+			err := os.WriteFile(queryFile, []byte(tt.queries), 0644)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/gomod/gomod.go
+++ b/internal/gomod/gomod.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"github.com/jschaf/pggen/internal/paths"
 	"golang.org/x/mod/modfile"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sync"
@@ -45,7 +44,7 @@ func ParsePath() (string, error) {
 			return
 		}
 		p := filepath.Join(dir, "go.mod")
-		bs, err := ioutil.ReadFile(p)
+		bs, err := os.ReadFile(p)
 		if err != nil {
 			goModPathErr = fmt.Errorf("read go.mod: %w", err)
 			return

--- a/internal/parser/interface.go
+++ b/internal/parser/interface.go
@@ -7,7 +7,7 @@ import (
 	"github.com/jschaf/pggen/internal/ast"
 	gotok "go/token"
 	"io"
-	"io/ioutil"
+	"os"
 )
 
 // If src != nil, readSource converts src to a []byte if possible; otherwise it
@@ -26,11 +26,11 @@ func readSource(filename string, src interface{}) ([]byte, error) {
 				return s.Bytes(), nil
 			}
 		case io.Reader:
-			return ioutil.ReadAll(s)
+			return io.ReadAll(s)
 		}
 		return nil, errors.New("invalid source")
 	}
-	return ioutil.ReadFile(filename)
+	return os.ReadFile(filename)
 }
 
 // A Mode value is a set of flags (or 0).

--- a/internal/pgdocker/pgdocker.go
+++ b/internal/pgdocker/pgdocker.go
@@ -17,7 +17,6 @@ import (
 	"go.uber.org/multierr"
 	"go.uber.org/zap"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -99,7 +98,7 @@ func (c *Client) GetContainerLogs() (logs string, mErr error) {
 	if err != nil {
 		return "", fmt.Errorf("get container logs: %w", err)
 	}
-	bs, err := ioutil.ReadAll(logsR)
+	bs, err := io.ReadAll(logsR)
 	if err != nil {
 		return "", fmt.Errorf("reall all container logs: %w", err)
 	}
@@ -157,7 +156,7 @@ func (c *Client) buildImage(ctx context.Context, initScripts []string) (id strin
 		return "", fmt.Errorf("build postgres docker image: %w", err)
 	}
 	defer errs.Capture(&mErr, resp.Body.Close, "close image build response")
-	response, err := ioutil.ReadAll(resp.Body)
+	response, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", fmt.Errorf("read image build response: %w", err)
 	}

--- a/internal/pgtest/pg_test_db.go
+++ b/internal/pgtest/pg_test_db.go
@@ -5,8 +5,8 @@ import (
 	crand "crypto/rand"
 	"encoding/binary"
 	"github.com/jackc/pgx/v4"
-	"io/ioutil"
 	"math/rand"
+	"os"
 	"strconv"
 	"strings"
 	"testing"
@@ -82,7 +82,7 @@ func NewPostgresSchema(t *testing.T, sqlFiles []string, opts ...Option) (*pgx.Co
 	t.Helper()
 	sb := &strings.Builder{}
 	for _, file := range sqlFiles {
-		bs, err := ioutil.ReadFile(file)
+		bs, err := os.ReadFile(file)
 		if err != nil {
 			t.Fatalf("read test db sql file: %s", err)
 		}


### PR DESCRIPTION
Since go 1.16, `ioutil` has been deprecated. Its use triggers warnings
when linting with `golangci-lint`.

Migrate from `ioutil` to `io` and `os`, as specified at:
https://go.dev/doc/go1.16#ioutil