### PR TITLE
feat: go type mapping per query argument

### DIFF
--- a/internal/ast/ast.go
+++ b/internal/ast/ast.go
@@ -88,15 +88,16 @@ type (
 
 	// An SourceQuery node represents a query entry from the source code.
 	SourceQuery struct {
-		Name        string        // name of the query
-		Doc         *CommentGroup // associated documentation; or nil
-		Start       gotok.Pos     // position of the start token, like 'SELECT' or 'UPDATE'
-		SourceSQL   string        // the complete sql query as it appeared in the source file
-		PreparedSQL string        // the sql query with args replaced by $1, $2, etc.
-		ParamNames  []string      // the name of each param in the PreparedSQL, the nth entry is the $n+1 param
-		ResultKind  ResultKind    // the result output type
-		Pragmas     Pragmas       // optional query options
-		Semi        gotok.Pos     // position of the closing semicolon
+		Name               string            // name of the query
+		Doc                *CommentGroup     // associated documentation; or nil
+		Start              gotok.Pos         // position of the start token, like 'SELECT' or 'UPDATE'
+		SourceSQL          string            // the complete sql query as it appeared in the source file
+		PreparedSQL        string            // the sql query with args replaced by $1, $2, etc.
+		ParamNames         []string          // the name of each param in the PreparedSQL, the nth entry is the $n+1 param
+		ParamTypeOverrides map[string]string // map of Go type to override the Pg type of a param
+		ResultKind         ResultKind        // the result output type
+		Pragmas            Pragmas           // optional query options
+		Semi               gotok.Pos         // position of the closing semicolon
 	}
 )
 

--- a/internal/codegen/golang/templater.go
+++ b/internal/codegen/golang/templater.go
@@ -144,10 +144,15 @@ func (tm Templater) templateFile(file codegen.QueryFile, isLeader bool) (Templat
 		// Build inputs.
 		inputs := make([]TemplatedParam, len(query.Inputs))
 		for i, input := range query.Inputs {
-			goType, err := tm.resolver.Resolve(input.PgType /*nullable*/, false, pkgPath)
-			if err != nil {
-				return TemplatedFile{}, nil, err
+			goType := input.TypeOverride
+			var err error
+			if goType == nil { // no custom arg type defined
+				goType, err = tm.resolver.Resolve(input.PgType /*nullable*/, false, pkgPath)
+				if err != nil {
+					return TemplatedFile{}, nil, err
+				}
 			}
+
 			imports.AddType(goType)
 			inputs[i] = TemplatedParam{
 				UpperName: tm.chooseUpperName(input.PgName, "UnnamedParam", i, len(query.Inputs)),


### PR DESCRIPTION
Extends the query annotation to specify custom go types using the same
qualified go type format as for the general custom type mapping.

Closes #46