### PR TITLE
Fix result type decl for nullable :one queries

### DIFF
--- a/example/author/query.sql
+++ b/example/author/query.sql
@@ -10,6 +10,10 @@ SELECT * FROM author WHERE first_name = pggen.arg('FirstName');
 -- name: FindAuthorNames :many
 SELECT first_name, last_name FROM author ORDER BY author_id = pggen.arg('AuthorID');
 
+-- FindFirstNames finds one (or zero) authors by ID.
+-- name: FindFirstNames :many
+SELECT first_name FROM author ORDER BY author_id = pggen.arg('AuthorID');
+
 -- DeleteAuthors deletes authors with a first name of "joe".
 -- name: DeleteAuthors :exec
 DELETE FROM author WHERE first_name = 'joe';
@@ -38,3 +42,9 @@ RETURNING author_id;
 INSERT INTO author (first_name, last_name, suffix)
 VALUES (pggen.arg('FirstName'), pggen.arg('LastName'), pggen.arg('Suffix'))
 RETURNING author_id, first_name, last_name, suffix;
+
+-- name: StringAggFirstName :one
+SELECT string_agg(first_name, ',') AS names FROM author WHERE author_id = pggen.arg('author_id');
+
+-- name: ArrayAggFirstName :one
+SELECT array_agg(first_name) AS names FROM author WHERE author_id = pggen.arg('author_id');

--- a/example/go_pointer_types/query.sql.go
+++ b/example/go_pointer_types/query.sql.go
@@ -198,11 +198,11 @@ LIMIT 1;`
 func (q *DBQuerier) GenSeries1(ctx context.Context) (*int, error) {
 	ctx = context.WithValue(ctx, "pggen_query_name", "GenSeries1")
 	row := q.conn.QueryRow(ctx, genSeries1SQL)
-	var item int
+	var item *int
 	if err := row.Scan(&item); err != nil {
-		return &item, fmt.Errorf("query GenSeries1: %w", err)
+		return item, fmt.Errorf("query GenSeries1: %w", err)
 	}
-	return &item, nil
+	return item, nil
 }
 
 // GenSeries1Batch implements Querier.GenSeries1Batch.
@@ -213,11 +213,11 @@ func (q *DBQuerier) GenSeries1Batch(batch genericBatch) {
 // GenSeries1Scan implements Querier.GenSeries1Scan.
 func (q *DBQuerier) GenSeries1Scan(results pgx.BatchResults) (*int, error) {
 	row := results.QueryRow()
-	var item int
+	var item *int
 	if err := row.Scan(&item); err != nil {
-		return &item, fmt.Errorf("scan GenSeries1Batch row: %w", err)
+		return item, fmt.Errorf("scan GenSeries1Batch row: %w", err)
 	}
-	return &item, nil
+	return item, nil
 }
 
 const genSeriesSQL = `SELECT n
@@ -359,11 +359,11 @@ LIMIT 1;`
 func (q *DBQuerier) GenSeriesStr1(ctx context.Context) (*string, error) {
 	ctx = context.WithValue(ctx, "pggen_query_name", "GenSeriesStr1")
 	row := q.conn.QueryRow(ctx, genSeriesStr1SQL)
-	var item string
+	var item *string
 	if err := row.Scan(&item); err != nil {
-		return &item, fmt.Errorf("query GenSeriesStr1: %w", err)
+		return item, fmt.Errorf("query GenSeriesStr1: %w", err)
 	}
-	return &item, nil
+	return item, nil
 }
 
 // GenSeriesStr1Batch implements Querier.GenSeriesStr1Batch.
@@ -374,11 +374,11 @@ func (q *DBQuerier) GenSeriesStr1Batch(batch genericBatch) {
 // GenSeriesStr1Scan implements Querier.GenSeriesStr1Scan.
 func (q *DBQuerier) GenSeriesStr1Scan(results pgx.BatchResults) (*string, error) {
 	row := results.QueryRow()
-	var item string
+	var item *string
 	if err := row.Scan(&item); err != nil {
-		return &item, fmt.Errorf("scan GenSeriesStr1Batch row: %w", err)
+		return item, fmt.Errorf("scan GenSeriesStr1Batch row: %w", err)
 	}
-	return &item, nil
+	return item, nil
 }
 
 const genSeriesStrSQL = `SELECT n::text

--- a/example/slices/query.sql.go
+++ b/example/slices/query.sql.go
@@ -266,11 +266,11 @@ const getOneTimestampSQL = `SELECT $1::timestamp;`
 func (q *DBQuerier) GetOneTimestamp(ctx context.Context, data *time.Time) (*time.Time, error) {
 	ctx = context.WithValue(ctx, "pggen_query_name", "GetOneTimestamp")
 	row := q.conn.QueryRow(ctx, getOneTimestampSQL, data)
-	var item time.Time
+	var item *time.Time
 	if err := row.Scan(&item); err != nil {
-		return &item, fmt.Errorf("query GetOneTimestamp: %w", err)
+		return item, fmt.Errorf("query GetOneTimestamp: %w", err)
 	}
-	return &item, nil
+	return item, nil
 }
 
 // GetOneTimestampBatch implements Querier.GetOneTimestampBatch.
@@ -281,11 +281,11 @@ func (q *DBQuerier) GetOneTimestampBatch(batch genericBatch, data *time.Time) {
 // GetOneTimestampScan implements Querier.GetOneTimestampScan.
 func (q *DBQuerier) GetOneTimestampScan(results pgx.BatchResults) (*time.Time, error) {
 	row := results.QueryRow()
-	var item time.Time
+	var item *time.Time
 	if err := row.Scan(&item); err != nil {
-		return &item, fmt.Errorf("scan GetOneTimestampBatch row: %w", err)
+		return item, fmt.Errorf("scan GetOneTimestampBatch row: %w", err)
 	}
-	return &item, nil
+	return item, nil
 }
 
 const getManyTimestamptzsSQL = `SELECT *


### PR DESCRIPTION
Previously, if a query returned a single nullable column, pggen would return the correct type *string, but only because we took the address of the input.

Bad code:

	var item string
	if err := row.Scan(&item); err != nil {
		return &item, fmt.Errorf("query StringAggFirstName: %w", err)
	}
	return &item, nil

Fixed code:

	var item *string
	if err := row.Scan(&item); err != nil {
		return item, fmt.Errorf("query StringAggFirstName: %w", err)
	}
	return item, nil

Fixes #75.