### PR TITLE
feat: handle dot paths on the output directory

### DIFF
--- a/cmd/pggen/pggen.go
+++ b/cmd/pggen/pggen.go
@@ -4,16 +4,17 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
 	"github.com/bmatcuk/doublestar"
 	"github.com/jschaf/pggen"
 	"github.com/jschaf/pggen/internal/flags"
 	"github.com/jschaf/pggen/internal/texts"
 	"github.com/peterbourgon/ff/v3/ffcli"
 	"go.uber.org/zap"
-	"os"
-	"path/filepath"
-	"sort"
-	"strings"
 )
 
 // Set via ldflags for release binaries.
@@ -129,6 +130,8 @@ func newGenCmd() *ffcli.Command {
 					outDir = dir
 				}
 			}
+
+			outDir, _ = filepath.Abs(outDir)
 
 			// Parse two acronym formats: "--acronym api" and "--acronym oids=OIDs"
 			acros := make(map[string]string)


### PR DESCRIPTION
Use the absolute path for output directory.

Examples, if you're in the following directory `/home/root/workspace/random`

- `.` -> `/home/root/workspace/random`
- `../` -> `/home/root/workspace`
- `/var` -> `/var`
- `./foo` -> `/home/root/workspace/foo`
- `bar` -> `/home/root/workspace/bar`

This means the Go package resolution from the output directory will not be set to `.` or `..` as mentioned in #48 .