### PR TITLE
Remove all batch queries

### DIFF
--- a/example/author/query.sql_test.go
+++ b/example/author/query.sql_test.go
@@ -3,7 +3,6 @@ package author
 import (
 	"context"
 	"errors"
-	"github.com/jschaf/pggen/internal/errs"
 	"github.com/jschaf/pggen/internal/ptrs"
 	"github.com/stretchr/testify/require"
 	"testing"
@@ -39,21 +38,6 @@ func TestNewQuerier_FindAuthorByID(t *testing.T) {
 		if !errors.Is(err, pgx.ErrNoRows) {
 			t.Fatalf("expected no rows error to wrap pgx.ErrNoRows; got %s", err)
 		}
-	})
-
-	t.Run("FindAuthorByIDBatch", func(t *testing.T) {
-		batch := &pgx.Batch{}
-		q.FindAuthorByIDBatch(batch, adamsID)
-		results := conn.SendBatch(context.Background(), batch)
-		defer errs.CaptureT(t, results.Close, "close batch results")
-		authors, err := q.FindAuthorByIDScan(results)
-		require.NoError(t, err)
-		assert.Equal(t, FindAuthorByIDRow{
-			AuthorID:  adamsID,
-			FirstName: "john",
-			LastName:  "adams",
-			Suffix:    nil,
-		}, authors)
 	})
 }
 
@@ -93,20 +77,6 @@ func TestNewQuerier_FindAuthors(t *testing.T) {
 		authors, err := q.FindAuthors(context.Background(), "joe")
 		require.NoError(t, err)
 		assert.Equal(t, []FindAuthorsRow{}, authors)
-	})
-
-	t.Run("FindAuthorsBatch", func(t *testing.T) {
-		batch := &pgx.Batch{}
-		q.FindAuthorsBatch(batch, "george")
-		results := conn.SendBatch(context.Background(), batch)
-		authors, err := q.FindAuthorsScan(results)
-		defer errs.CaptureT(t, results.Close, "close batch results")
-		require.NoError(t, err)
-		want := []FindAuthorsRow{
-			{AuthorID: washingtonID, FirstName: "george", LastName: "washington", Suffix: nil},
-			{AuthorID: carverID, FirstName: "george", LastName: "carver", Suffix: nil},
-		}
-		assert.Equal(t, want, authors)
 	})
 }
 
@@ -150,16 +120,6 @@ func TestNewQuerier_FindFirstNames(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, []*string{ptrs.String("george"), ptrs.String("john")}, firstNames)
 	})
-
-	t.Run("FindFirstNamesBatch", func(t *testing.T) {
-		batch := &pgx.Batch{}
-		q.FindFirstNamesBatch(batch, adamsID)
-		results := conn.SendBatch(context.Background(), batch)
-		defer errs.CaptureT(t, results.Close, "close batch results")
-		firstNames, err := q.FindFirstNamesScan(results)
-		require.NoError(t, err)
-		assert.Equal(t, []*string{ptrs.String("george"), ptrs.String("john")}, firstNames)
-	})
 }
 
 func TestNewQuerier_InsertAuthorSuffix(t *testing.T) {
@@ -183,26 +143,6 @@ func TestNewQuerier_InsertAuthorSuffix(t *testing.T) {
 		}
 		assert.Equal(t, want, author)
 	})
-
-	t.Run("InsertAuthorSuffixBatch", func(t *testing.T) {
-		batch := &pgx.Batch{}
-		q.InsertAuthorSuffixBatch(batch, InsertAuthorSuffixParams{
-			FirstName: "ulysses",
-			LastName:  "grant",
-		})
-		results := conn.SendBatch(context.Background(), batch)
-		defer errs.CaptureT(t, results.Close, "close batch results")
-		author, err := q.InsertAuthorSuffixScan(results)
-		require.NoError(t, err)
-		empty := ""
-		want := InsertAuthorSuffixRow{
-			AuthorID:  author.AuthorID,
-			FirstName: "ulysses",
-			LastName:  "grant",
-			Suffix:    &empty, // TODO: should be nil, https://github.com/jschaf/pggen/issues/21
-		}
-		assert.Equal(t, want, author)
-	})
 }
 
 func TestNewQuerier_DeleteAuthorsByFirstName(t *testing.T) {
@@ -218,30 +158,6 @@ func TestNewQuerier_DeleteAuthorsByFirstName(t *testing.T) {
 		require.NoError(t, err)
 		assert.Truef(t, tag.Delete(), "expected delete tag; got %s", tag.String())
 		assert.Equal(t, int64(2), tag.RowsAffected())
-
-		authors, err := q.FindAuthors(context.Background(), "george")
-		require.NoError(t, err)
-		assert.Empty(t, authors, "no authors should remain with first name of george")
-	})
-}
-
-func TestNewQuerier_DeleteAuthorsByFirstNameBatch(t *testing.T) {
-	conn, cleanup := pgtest.NewPostgresSchema(t, []string{"schema.sql"})
-	defer cleanup()
-	q := NewQuerier(conn)
-	insertAuthor(t, q, "john", "adams")
-	insertAuthor(t, q, "george", "washington")
-	insertAuthor(t, q, "george", "carver")
-
-	t.Run("DeleteAuthorsByFirstNameBatch", func(t *testing.T) {
-		batch := &pgx.Batch{}
-		q.DeleteAuthorsByFirstNameBatch(batch, "george")
-		results := conn.SendBatch(context.Background(), batch)
-		tag, err := q.DeleteAuthorsByFirstNameScan(results)
-		require.NoError(t, err)
-		assert.Truef(t, tag.Delete(), "expected delete tag; got %s", tag.String())
-		assert.Equal(t, int64(2), tag.RowsAffected())
-		require.NoError(t, results.Close())
 
 		authors, err := q.FindAuthors(context.Background(), "george")
 		require.NoError(t, err)
@@ -285,46 +201,6 @@ func TestNewQuerier_DeleteAuthorsByFullName(t *testing.T) {
 	})
 }
 
-func TestNewQuerier_DeleteAuthorsByFullNameBatch(t *testing.T) {
-	conn, cleanup := pgtest.NewPostgresSchema(t, []string{"schema.sql"})
-	defer cleanup()
-	q := NewQuerier(conn)
-	washingtonID := insertAuthor(t, q, "george", "washington")
-	_, err := q.InsertAuthorSuffix(context.Background(), InsertAuthorSuffixParams{
-		FirstName: "george",
-		LastName:  "washington",
-		Suffix:    "Jr.",
-	})
-	require.NoError(t, err)
-
-	t.Run("DeleteAuthorsByFullNameBatch", func(t *testing.T) {
-		batch := &pgx.Batch{}
-		q.DeleteAuthorsByFullNameBatch(batch, DeleteAuthorsByFullNameParams{
-			FirstName: "george",
-			LastName:  "washington",
-			Suffix:    "Jr.",
-		})
-		results := conn.SendBatch(context.Background(), batch)
-		tag, err := q.DeleteAuthorsByFullNameScan(results)
-		require.NoError(t, err)
-		assert.Truef(t, tag.Delete(), "expected delete tag; got %s", tag.String())
-		assert.Equal(t, int64(1), tag.RowsAffected())
-		require.NoError(t, results.Close())
-
-		authors, err := q.FindAuthors(context.Background(), "george")
-		require.NoError(t, err)
-		want := []FindAuthorsRow{
-			{
-				AuthorID:  washingtonID,
-				FirstName: "george",
-				LastName:  "washington",
-				Suffix:    nil,
-			},
-		}
-		assert.Equal(t, want, authors, "only one author with first name george should remain")
-	})
-}
-
 func TestNewQuerier_StringAggFirstName(t *testing.T) {
 	conn, cleanup := pgtest.NewPostgresSchema(t, []string{"schema.sql"})
 	defer cleanup()
@@ -343,28 +219,8 @@ func TestNewQuerier_StringAggFirstName(t *testing.T) {
 		require.Nil(t, firstNames)
 	})
 
-	t.Run("StringAggFirstNameBatch - null", func(t *testing.T) {
-		batch := &pgx.Batch{}
-		q.StringAggFirstNameBatch(batch, 999)
-		results := conn.SendBatch(context.Background(), batch)
-		defer errs.CaptureT(t, results.Close, "close results")
-		firstNames, err := q.StringAggFirstNameScan(results)
-		require.NoError(t, err)
-		require.Nil(t, firstNames)
-	})
-
 	t.Run("StringAggFirstName - one", func(t *testing.T) {
 		firstNames, err := q.StringAggFirstName(context.Background(), washingtonID)
-		require.NoError(t, err)
-		assert.Equal(t, "george", *firstNames)
-	})
-
-	t.Run("StringAggFirstNameBatch - one", func(t *testing.T) {
-		batch := &pgx.Batch{}
-		q.StringAggFirstNameBatch(batch, washingtonID)
-		results := conn.SendBatch(context.Background(), batch)
-		defer errs.CaptureT(t, results.Close, "close results")
-		firstNames, err := q.StringAggFirstNameScan(results)
 		require.NoError(t, err)
 		assert.Equal(t, "george", *firstNames)
 	})
@@ -388,28 +244,8 @@ func TestNewQuerier_ArrayAggFirstName(t *testing.T) {
 		require.Nil(t, firstNames)
 	})
 
-	t.Run("ArrayAggFirstNameBatch - null", func(t *testing.T) {
-		batch := &pgx.Batch{}
-		q.ArrayAggFirstNameBatch(batch, 999)
-		results := conn.SendBatch(context.Background(), batch)
-		defer errs.CaptureT(t, results.Close, "close results")
-		firstNames, err := q.ArrayAggFirstNameScan(results)
-		require.NoError(t, err)
-		require.Nil(t, firstNames)
-	})
-
 	t.Run("ArrayAggFirstName - one", func(t *testing.T) {
 		firstNames, err := q.ArrayAggFirstName(context.Background(), washingtonID)
-		require.NoError(t, err)
-		assert.Equal(t, []string{"george"}, firstNames)
-	})
-
-	t.Run("ArrayAggFirstNameBatch - one", func(t *testing.T) {
-		batch := &pgx.Batch{}
-		q.ArrayAggFirstNameBatch(batch, washingtonID)
-		results := conn.SendBatch(context.Background(), batch)
-		defer errs.CaptureT(t, results.Close, "close results")
-		firstNames, err := q.ArrayAggFirstNameScan(results)
 		require.NoError(t, err)
 		assert.Equal(t, []string{"george"}, firstNames)
 	})

--- a/example/complex_params/query.sql_test.go
+++ b/example/complex_params/query.sql_test.go
@@ -2,7 +2,6 @@ package complex_params
 
 import (
 	"context"
-	"github.com/jackc/pgx/v4"
 	"github.com/jschaf/pggen/internal/pgtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -23,17 +22,6 @@ func TestNewQuerier_ParamArrayInt(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, want, row)
 	})
-
-	t.Run("ParamArrayIntBatch", func(t *testing.T) {
-		batch := &pgx.Batch{}
-		q.ParamArrayIntBatch(batch, want)
-		results := conn.SendBatch(ctx, batch)
-		row, err := q.ParamArrayIntScan(results)
-		if err != nil {
-			t.Fatal(err)
-		}
-		assert.Equal(t, want, row)
-	})
 }
 
 func TestNewQuerier_ParamNested1(t *testing.T) {
@@ -48,17 +36,6 @@ func TestNewQuerier_ParamNested1(t *testing.T) {
 	t.Run("ParamNested1", func(t *testing.T) {
 		row, err := q.ParamNested1(ctx, want)
 		require.NoError(t, err)
-		assert.Equal(t, want, row)
-	})
-
-	t.Run("ParamNested1Batch", func(t *testing.T) {
-		batch := &pgx.Batch{}
-		q.ParamNested1Batch(batch, want)
-		results := conn.SendBatch(ctx, batch)
-		row, err := q.ParamNested1Scan(results)
-		if err != nil {
-			t.Fatal(err)
-		}
 		assert.Equal(t, want, row)
 	})
 }
@@ -80,17 +57,6 @@ func TestNewQuerier_ParamNested2(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, want, row)
 	})
-
-	t.Run("ParamNested2Batch", func(t *testing.T) {
-		batch := &pgx.Batch{}
-		q.ParamNested2Batch(batch, want)
-		results := conn.SendBatch(ctx, batch)
-		row, err := q.ParamNested2Scan(results)
-		if err != nil {
-			t.Fatal(err)
-		}
-		assert.Equal(t, want, row)
-	})
 }
 
 func TestNewQuerier_ParamNested2Array(t *testing.T) {
@@ -108,17 +74,6 @@ func TestNewQuerier_ParamNested2Array(t *testing.T) {
 	t.Run("ParamNested2Array", func(t *testing.T) {
 		row, err := q.ParamNested2Array(ctx, want)
 		require.NoError(t, err)
-		assert.Equal(t, want, row)
-	})
-
-	t.Run("ParamNested2ArrayBatch", func(t *testing.T) {
-		batch := &pgx.Batch{}
-		q.ParamNested2ArrayBatch(batch, want)
-		results := conn.SendBatch(ctx, batch)
-		row, err := q.ParamNested2ArrayScan(results)
-		if err != nil {
-			t.Fatal(err)
-		}
 		assert.Equal(t, want, row)
 	})
 }
@@ -144,17 +99,6 @@ func TestNewQuerier_ParamNested3(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, want, row)
 	})
-
-	t.Run("ParamNested3Batch", func(t *testing.T) {
-		batch := &pgx.Batch{}
-		q.ParamNested3Batch(batch, want)
-		results := conn.SendBatch(ctx, batch)
-		row, err := q.ParamNested3Scan(results)
-		if err != nil {
-			t.Fatal(err)
-		}
-		assert.Equal(t, want, row)
-	})
 }
 
 func TestNewQuerier_ParamNested3_QueryAllDataTypes(t *testing.T) {
@@ -177,17 +121,6 @@ func TestNewQuerier_ParamNested3_QueryAllDataTypes(t *testing.T) {
 	t.Run("ParamNested3", func(t *testing.T) {
 		row, err := q.ParamNested3(ctx, want)
 		require.NoError(t, err)
-		assert.Equal(t, want, row)
-	})
-
-	t.Run("ParamNested3Batch", func(t *testing.T) {
-		batch := &pgx.Batch{}
-		q.ParamNested3Batch(batch, want)
-		results := conn.SendBatch(ctx, batch)
-		row, err := q.ParamNested3Scan(results)
-		if err != nil {
-			t.Fatal(err)
-		}
 		assert.Equal(t, want, row)
 	})
 }

--- a/example/composite/query.sql.go
+++ b/example/composite/query.sql.go
@@ -11,45 +11,16 @@ import (
 )
 
 // Querier is a typesafe Go interface backed by SQL queries.
-//
-// Methods ending with Batch enqueue a query to run later in a pgx.Batch. After
-// calling SendBatch on pgx.Conn, pgxpool.Pool, or pgx.Tx, use the Scan methods
-// to parse the results.
 type Querier interface {
 	SearchScreenshots(ctx context.Context, params SearchScreenshotsParams) ([]SearchScreenshotsRow, error)
-	// SearchScreenshotsBatch enqueues a SearchScreenshots query into batch to be executed
-	// later by the batch.
-	SearchScreenshotsBatch(batch genericBatch, params SearchScreenshotsParams)
-	// SearchScreenshotsScan scans the result of an executed SearchScreenshotsBatch query.
-	SearchScreenshotsScan(results pgx.BatchResults) ([]SearchScreenshotsRow, error)
 
 	SearchScreenshotsOneCol(ctx context.Context, params SearchScreenshotsOneColParams) ([][]Blocks, error)
-	// SearchScreenshotsOneColBatch enqueues a SearchScreenshotsOneCol query into batch to be executed
-	// later by the batch.
-	SearchScreenshotsOneColBatch(batch genericBatch, params SearchScreenshotsOneColParams)
-	// SearchScreenshotsOneColScan scans the result of an executed SearchScreenshotsOneColBatch query.
-	SearchScreenshotsOneColScan(results pgx.BatchResults) ([][]Blocks, error)
 
 	InsertScreenshotBlocks(ctx context.Context, screenshotID int, body string) (InsertScreenshotBlocksRow, error)
-	// InsertScreenshotBlocksBatch enqueues a InsertScreenshotBlocks query into batch to be executed
-	// later by the batch.
-	InsertScreenshotBlocksBatch(batch genericBatch, screenshotID int, body string)
-	// InsertScreenshotBlocksScan scans the result of an executed InsertScreenshotBlocksBatch query.
-	InsertScreenshotBlocksScan(results pgx.BatchResults) (InsertScreenshotBlocksRow, error)
 
 	ArraysInput(ctx context.Context, arrays Arrays) (Arrays, error)
-	// ArraysInputBatch enqueues a ArraysInput query into batch to be executed
-	// later by the batch.
-	ArraysInputBatch(batch genericBatch, arrays Arrays)
-	// ArraysInputScan scans the result of an executed ArraysInputBatch query.
-	ArraysInputScan(results pgx.BatchResults) (Arrays, error)
 
 	UserEmails(ctx context.Context) (UserEmail, error)
-	// UserEmailsBatch enqueues a UserEmails query into batch to be executed
-	// later by the batch.
-	UserEmailsBatch(batch genericBatch)
-	// UserEmailsScan scans the result of an executed UserEmailsBatch query.
-	UserEmailsScan(results pgx.BatchResults) (UserEmail, error)
 }
 
 type DBQuerier struct {
@@ -76,14 +47,6 @@ type genericConn interface {
 	// string. arguments should be referenced positionally from the sql string
 	// as $1, $2, etc.
 	Exec(ctx context.Context, sql string, arguments ...interface{}) (pgconn.CommandTag, error)
-}
-
-// genericBatch batches queries to send in a single network request to a
-// Postgres server. This is usually backed by *pgx.Batch.
-type genericBatch interface {
-	// Queue queues a query to batch b. query can be an SQL query or the name of a
-	// prepared statement. See Queue on *pgx.Batch.
-	Queue(query string, arguments ...interface{})
 }
 
 // NewQuerier creates a DBQuerier that implements Querier. conn is typically
@@ -365,36 +328,6 @@ func (q *DBQuerier) SearchScreenshots(ctx context.Context, params SearchScreensh
 	return items, err
 }
 
-// SearchScreenshotsBatch implements Querier.SearchScreenshotsBatch.
-func (q *DBQuerier) SearchScreenshotsBatch(batch genericBatch, params SearchScreenshotsParams) {
-	batch.Queue(searchScreenshotsSQL, params.Body, params.Limit, params.Offset)
-}
-
-// SearchScreenshotsScan implements Querier.SearchScreenshotsScan.
-func (q *DBQuerier) SearchScreenshotsScan(results pgx.BatchResults) ([]SearchScreenshotsRow, error) {
-	rows, err := results.Query()
-	if err != nil {
-		return nil, fmt.Errorf("query SearchScreenshotsBatch: %w", err)
-	}
-	defer rows.Close()
-	items := []SearchScreenshotsRow{}
-	blocksArray := q.types.newBlocksArray()
-	for rows.Next() {
-		var item SearchScreenshotsRow
-		if err := rows.Scan(&item.ID, blocksArray); err != nil {
-			return nil, fmt.Errorf("scan SearchScreenshotsBatch row: %w", err)
-		}
-		if err := blocksArray.AssignTo(&item.Blocks); err != nil {
-			return nil, fmt.Errorf("assign SearchScreenshots row: %w", err)
-		}
-		items = append(items, item)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("close SearchScreenshotsBatch rows: %w", err)
-	}
-	return items, err
-}
-
 const searchScreenshotsOneColSQL = `SELECT
   array_agg(bl) AS blocks
 FROM screenshots ss
@@ -436,36 +369,6 @@ func (q *DBQuerier) SearchScreenshotsOneCol(ctx context.Context, params SearchSc
 	return items, err
 }
 
-// SearchScreenshotsOneColBatch implements Querier.SearchScreenshotsOneColBatch.
-func (q *DBQuerier) SearchScreenshotsOneColBatch(batch genericBatch, params SearchScreenshotsOneColParams) {
-	batch.Queue(searchScreenshotsOneColSQL, params.Body, params.Limit, params.Offset)
-}
-
-// SearchScreenshotsOneColScan implements Querier.SearchScreenshotsOneColScan.
-func (q *DBQuerier) SearchScreenshotsOneColScan(results pgx.BatchResults) ([][]Blocks, error) {
-	rows, err := results.Query()
-	if err != nil {
-		return nil, fmt.Errorf("query SearchScreenshotsOneColBatch: %w", err)
-	}
-	defer rows.Close()
-	items := [][]Blocks{}
-	blocksArray := q.types.newBlocksArray()
-	for rows.Next() {
-		var item []Blocks
-		if err := rows.Scan(blocksArray); err != nil {
-			return nil, fmt.Errorf("scan SearchScreenshotsOneColBatch row: %w", err)
-		}
-		if err := blocksArray.AssignTo(&item); err != nil {
-			return nil, fmt.Errorf("assign SearchScreenshotsOneCol row: %w", err)
-		}
-		items = append(items, item)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("close SearchScreenshotsOneColBatch rows: %w", err)
-	}
-	return items, err
-}
-
 const insertScreenshotBlocksSQL = `WITH screens AS (
   INSERT INTO screenshots (id) VALUES ($1)
     ON CONFLICT DO NOTHING
@@ -492,21 +395,6 @@ func (q *DBQuerier) InsertScreenshotBlocks(ctx context.Context, screenshotID int
 	return item, nil
 }
 
-// InsertScreenshotBlocksBatch implements Querier.InsertScreenshotBlocksBatch.
-func (q *DBQuerier) InsertScreenshotBlocksBatch(batch genericBatch, screenshotID int, body string) {
-	batch.Queue(insertScreenshotBlocksSQL, screenshotID, body)
-}
-
-// InsertScreenshotBlocksScan implements Querier.InsertScreenshotBlocksScan.
-func (q *DBQuerier) InsertScreenshotBlocksScan(results pgx.BatchResults) (InsertScreenshotBlocksRow, error) {
-	row := results.QueryRow()
-	var item InsertScreenshotBlocksRow
-	if err := row.Scan(&item.ID, &item.ScreenshotID, &item.Body); err != nil {
-		return item, fmt.Errorf("scan InsertScreenshotBlocksBatch row: %w", err)
-	}
-	return item, nil
-}
-
 const arraysInputSQL = `SELECT $1::arrays;`
 
 // ArraysInput implements Querier.ArraysInput.
@@ -524,25 +412,6 @@ func (q *DBQuerier) ArraysInput(ctx context.Context, arrays Arrays) (Arrays, err
 	return item, nil
 }
 
-// ArraysInputBatch implements Querier.ArraysInputBatch.
-func (q *DBQuerier) ArraysInputBatch(batch genericBatch, arrays Arrays) {
-	batch.Queue(arraysInputSQL, q.types.newArraysInit(arrays))
-}
-
-// ArraysInputScan implements Querier.ArraysInputScan.
-func (q *DBQuerier) ArraysInputScan(results pgx.BatchResults) (Arrays, error) {
-	row := results.QueryRow()
-	var item Arrays
-	arraysRow := q.types.newArrays()
-	if err := row.Scan(arraysRow); err != nil {
-		return item, fmt.Errorf("scan ArraysInputBatch row: %w", err)
-	}
-	if err := arraysRow.AssignTo(&item); err != nil {
-		return item, fmt.Errorf("assign ArraysInput row: %w", err)
-	}
-	return item, nil
-}
-
 const userEmailsSQL = `SELECT ('foo', 'bar@example.com')::user_email;`
 
 // UserEmails implements Querier.UserEmails.
@@ -553,25 +422,6 @@ func (q *DBQuerier) UserEmails(ctx context.Context) (UserEmail, error) {
 	rowRow := q.types.newUserEmail()
 	if err := row.Scan(rowRow); err != nil {
 		return item, fmt.Errorf("query UserEmails: %w", err)
-	}
-	if err := rowRow.AssignTo(&item); err != nil {
-		return item, fmt.Errorf("assign UserEmails row: %w", err)
-	}
-	return item, nil
-}
-
-// UserEmailsBatch implements Querier.UserEmailsBatch.
-func (q *DBQuerier) UserEmailsBatch(batch genericBatch) {
-	batch.Queue(userEmailsSQL)
-}
-
-// UserEmailsScan implements Querier.UserEmailsScan.
-func (q *DBQuerier) UserEmailsScan(results pgx.BatchResults) (UserEmail, error) {
-	row := results.QueryRow()
-	var item UserEmail
-	rowRow := q.types.newUserEmail()
-	if err := row.Scan(rowRow); err != nil {
-		return item, fmt.Errorf("scan UserEmailsBatch row: %w", err)
 	}
 	if err := rowRow.AssignTo(&item); err != nil {
 		return item, fmt.Errorf("assign UserEmails row: %w", err)

--- a/example/composite/query.sql_test.go
+++ b/example/composite/query.sql_test.go
@@ -3,9 +3,7 @@ package composite
 import (
 	"context"
 	"github.com/jackc/pgtype"
-	"github.com/jackc/pgx/v4"
 	"github.com/jschaf/pggen/internal/difftest"
-	"github.com/jschaf/pggen/internal/errs"
 	"github.com/jschaf/pggen/internal/pgtest"
 	"github.com/jschaf/pggen/internal/ptrs"
 	"github.com/stretchr/testify/assert"
@@ -49,40 +47,12 @@ func TestNewQuerier_SearchScreenshots(t *testing.T) {
 		assert.Equal(t, want, rows)
 	})
 
-	t.Run("SearchScreenshotsBatch", func(t *testing.T) {
-		batch := &pgx.Batch{}
-		q.SearchScreenshotsBatch(batch, SearchScreenshotsParams{
-			Body:   "body",
-			Limit:  5,
-			Offset: 0,
-		})
-		results := conn.SendBatch(context.Background(), batch)
-		defer errs.CaptureT(t, results.Close, "close batch results")
-		rows, err := q.SearchScreenshotsScan(results)
-		require.NoError(t, err)
-		assert.Equal(t, want, rows)
-	})
-
 	t.Run("SearchScreenshotsOneCol", func(t *testing.T) {
 		rows, err := q.SearchScreenshotsOneCol(context.Background(), SearchScreenshotsOneColParams{
 			Body:   "body",
 			Limit:  5,
 			Offset: 0,
 		})
-		require.NoError(t, err)
-		assert.Equal(t, [][]Blocks{want[0].Blocks}, rows)
-	})
-
-	t.Run("SearchScreenshotsOneColBatch", func(t *testing.T) {
-		batch := &pgx.Batch{}
-		q.SearchScreenshotsOneColBatch(batch, SearchScreenshotsOneColParams{
-			Body:   "body",
-			Limit:  5,
-			Offset: 0,
-		})
-		results := conn.SendBatch(context.Background(), batch)
-		defer errs.CaptureT(t, results.Close, "close batch results")
-		rows, err := q.SearchScreenshotsOneColScan(results)
 		require.NoError(t, err)
 		assert.Equal(t, [][]Blocks{want[0].Blocks}, rows)
 	})

--- a/example/custom_types/query.sql.go
+++ b/example/custom_types/query.sql.go
@@ -12,31 +12,12 @@ import (
 )
 
 // Querier is a typesafe Go interface backed by SQL queries.
-//
-// Methods ending with Batch enqueue a query to run later in a pgx.Batch. After
-// calling SendBatch on pgx.Conn, pgxpool.Pool, or pgx.Tx, use the Scan methods
-// to parse the results.
 type Querier interface {
 	CustomTypes(ctx context.Context) (CustomTypesRow, error)
-	// CustomTypesBatch enqueues a CustomTypes query into batch to be executed
-	// later by the batch.
-	CustomTypesBatch(batch genericBatch)
-	// CustomTypesScan scans the result of an executed CustomTypesBatch query.
-	CustomTypesScan(results pgx.BatchResults) (CustomTypesRow, error)
 
 	CustomMyInt(ctx context.Context) (int, error)
-	// CustomMyIntBatch enqueues a CustomMyInt query into batch to be executed
-	// later by the batch.
-	CustomMyIntBatch(batch genericBatch)
-	// CustomMyIntScan scans the result of an executed CustomMyIntBatch query.
-	CustomMyIntScan(results pgx.BatchResults) (int, error)
 
 	IntArray(ctx context.Context) ([][]int32, error)
-	// IntArrayBatch enqueues a IntArray query into batch to be executed
-	// later by the batch.
-	IntArrayBatch(batch genericBatch)
-	// IntArrayScan scans the result of an executed IntArrayBatch query.
-	IntArrayScan(results pgx.BatchResults) ([][]int32, error)
 }
 
 type DBQuerier struct {
@@ -63,14 +44,6 @@ type genericConn interface {
 	// string. arguments should be referenced positionally from the sql string
 	// as $1, $2, etc.
 	Exec(ctx context.Context, sql string, arguments ...interface{}) (pgconn.CommandTag, error)
-}
-
-// genericBatch batches queries to send in a single network request to a
-// Postgres server. This is usually backed by *pgx.Batch.
-type genericBatch interface {
-	// Queue queues a query to batch b. query can be an SQL query or the name of a
-	// prepared statement. See Queue on *pgx.Batch.
-	Queue(query string, arguments ...interface{})
 }
 
 // NewQuerier creates a DBQuerier that implements Querier. conn is typically
@@ -179,21 +152,6 @@ func (q *DBQuerier) CustomTypes(ctx context.Context) (CustomTypesRow, error) {
 	return item, nil
 }
 
-// CustomTypesBatch implements Querier.CustomTypesBatch.
-func (q *DBQuerier) CustomTypesBatch(batch genericBatch) {
-	batch.Queue(customTypesSQL)
-}
-
-// CustomTypesScan implements Querier.CustomTypesScan.
-func (q *DBQuerier) CustomTypesScan(results pgx.BatchResults) (CustomTypesRow, error) {
-	row := results.QueryRow()
-	var item CustomTypesRow
-	if err := row.Scan(&item.Column, &item.Int8); err != nil {
-		return item, fmt.Errorf("scan CustomTypesBatch row: %w", err)
-	}
-	return item, nil
-}
-
 const customMyIntSQL = `SELECT '5'::my_int as int5;`
 
 // CustomMyInt implements Querier.CustomMyInt.
@@ -203,21 +161,6 @@ func (q *DBQuerier) CustomMyInt(ctx context.Context) (int, error) {
 	var item int
 	if err := row.Scan(&item); err != nil {
 		return item, fmt.Errorf("query CustomMyInt: %w", err)
-	}
-	return item, nil
-}
-
-// CustomMyIntBatch implements Querier.CustomMyIntBatch.
-func (q *DBQuerier) CustomMyIntBatch(batch genericBatch) {
-	batch.Queue(customMyIntSQL)
-}
-
-// CustomMyIntScan implements Querier.CustomMyIntScan.
-func (q *DBQuerier) CustomMyIntScan(results pgx.BatchResults) (int, error) {
-	row := results.QueryRow()
-	var item int
-	if err := row.Scan(&item); err != nil {
-		return item, fmt.Errorf("scan CustomMyIntBatch row: %w", err)
 	}
 	return item, nil
 }
@@ -242,32 +185,6 @@ func (q *DBQuerier) IntArray(ctx context.Context) ([][]int32, error) {
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("close IntArray rows: %w", err)
-	}
-	return items, err
-}
-
-// IntArrayBatch implements Querier.IntArrayBatch.
-func (q *DBQuerier) IntArrayBatch(batch genericBatch) {
-	batch.Queue(intArraySQL)
-}
-
-// IntArrayScan implements Querier.IntArrayScan.
-func (q *DBQuerier) IntArrayScan(results pgx.BatchResults) ([][]int32, error) {
-	rows, err := results.Query()
-	if err != nil {
-		return nil, fmt.Errorf("query IntArrayBatch: %w", err)
-	}
-	defer rows.Close()
-	items := [][]int32{}
-	for rows.Next() {
-		var item []int32
-		if err := rows.Scan(&item); err != nil {
-			return nil, fmt.Errorf("scan IntArrayBatch row: %w", err)
-		}
-		items = append(items, item)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("close IntArrayBatch rows: %w", err)
 	}
 	return items, err
 }

--- a/example/custom_types/query.sql_test.go
+++ b/example/custom_types/query.sql_test.go
@@ -3,7 +3,6 @@ package custom_types
 import (
 	"context"
 	"github.com/jackc/pgtype"
-	"github.com/jackc/pgx/v4"
 	"github.com/jschaf/pggen/internal/pgtest"
 	"github.com/jschaf/pggen/internal/texts"
 	"github.com/stretchr/testify/assert"
@@ -19,19 +18,6 @@ func TestQuerier_CustomTypes(t *testing.T) {
 
 	t.Run("CustomTypes", func(t *testing.T) {
 		val, err := q.CustomTypes(ctx)
-		require.NoError(t, err)
-		want := CustomTypesRow{
-			Column: "some_text",
-			Int8:   1,
-		}
-		assert.Equal(t, want, val)
-	})
-
-	t.Run("CustomTypesBatch", func(t *testing.T) {
-		batch := &pgx.Batch{}
-		q.CustomTypesBatch(batch)
-		results := conn.SendBatch(context.Background(), batch)
-		val, err := q.CustomTypesScan(results)
 		require.NoError(t, err)
 		want := CustomTypesRow{
 			Column: "some_text",
@@ -71,15 +57,6 @@ func TestQuerier_CustomMyInt(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, 5, val)
 	})
-
-	t.Run("CustomMyIntBatch", func(t *testing.T) {
-		batch := &pgx.Batch{}
-		q.CustomMyIntBatch(batch)
-		results := conn.SendBatch(context.Background(), batch)
-		val, err := q.CustomMyIntScan(results)
-		require.NoError(t, err)
-		assert.Equal(t, 5, val)
-	})
 }
 
 func TestQuerier_IntArray(t *testing.T) {
@@ -92,14 +69,5 @@ func TestQuerier_IntArray(t *testing.T) {
 		array, err := q.IntArray(ctx)
 		require.NoError(t, err)
 		assert.Equal(t, [][]int32{{5, 6, 7}}, array)
-	})
-
-	t.Run("IntArrayBatch", func(t *testing.T) {
-		batch := &pgx.Batch{}
-		q.IntArrayBatch(batch)
-		results := conn.SendBatch(context.Background(), batch)
-		val, err := q.IntArrayScan(results)
-		assert.NoError(t, err)
-		assert.Equal(t, [][]int32{{5, 6, 7}}, val)
 	})
 }

--- a/example/domain/query.sql_test.go
+++ b/example/domain/query.sql_test.go
@@ -2,8 +2,6 @@ package domain
 
 import (
 	"context"
-	"github.com/jackc/pgx/v4"
-	"github.com/jschaf/pggen/internal/errs"
 	"github.com/jschaf/pggen/internal/pgtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -21,15 +19,5 @@ func TestQuerier_DomainOne(t *testing.T) {
 		postCode, err := q.DomainOne(ctx)
 		require.NoError(t, err)
 		assert.Equal(t, "90210", postCode)
-	})
-
-	t.Run("DomainOneBatch", func(t *testing.T) {
-		batch := &pgx.Batch{}
-		q.DomainOneBatch(batch)
-		results := conn.SendBatch(context.Background(), batch)
-		got, err := q.DomainOneScan(results)
-		defer errs.CaptureT(t, results.Close, "close batch")
-		require.NoError(t, err)
-		assert.Equal(t, "90210", got)
 	})
 }

--- a/example/enums/query.sql.go
+++ b/example/enums/query.sql.go
@@ -11,56 +11,22 @@ import (
 )
 
 // Querier is a typesafe Go interface backed by SQL queries.
-//
-// Methods ending with Batch enqueue a query to run later in a pgx.Batch. After
-// calling SendBatch on pgx.Conn, pgxpool.Pool, or pgx.Tx, use the Scan methods
-// to parse the results.
 type Querier interface {
 	FindAllDevices(ctx context.Context) ([]FindAllDevicesRow, error)
-	// FindAllDevicesBatch enqueues a FindAllDevices query into batch to be executed
-	// later by the batch.
-	FindAllDevicesBatch(batch genericBatch)
-	// FindAllDevicesScan scans the result of an executed FindAllDevicesBatch query.
-	FindAllDevicesScan(results pgx.BatchResults) ([]FindAllDevicesRow, error)
 
 	InsertDevice(ctx context.Context, mac pgtype.Macaddr, typePg DeviceType) (pgconn.CommandTag, error)
-	// InsertDeviceBatch enqueues a InsertDevice query into batch to be executed
-	// later by the batch.
-	InsertDeviceBatch(batch genericBatch, mac pgtype.Macaddr, typePg DeviceType)
-	// InsertDeviceScan scans the result of an executed InsertDeviceBatch query.
-	InsertDeviceScan(results pgx.BatchResults) (pgconn.CommandTag, error)
 
 	// Select an array of all device_type enum values.
 	FindOneDeviceArray(ctx context.Context) ([]DeviceType, error)
-	// FindOneDeviceArrayBatch enqueues a FindOneDeviceArray query into batch to be executed
-	// later by the batch.
-	FindOneDeviceArrayBatch(batch genericBatch)
-	// FindOneDeviceArrayScan scans the result of an executed FindOneDeviceArrayBatch query.
-	FindOneDeviceArrayScan(results pgx.BatchResults) ([]DeviceType, error)
 
 	// Select many rows of device_type enum values.
 	FindManyDeviceArray(ctx context.Context) ([][]DeviceType, error)
-	// FindManyDeviceArrayBatch enqueues a FindManyDeviceArray query into batch to be executed
-	// later by the batch.
-	FindManyDeviceArrayBatch(batch genericBatch)
-	// FindManyDeviceArrayScan scans the result of an executed FindManyDeviceArrayBatch query.
-	FindManyDeviceArrayScan(results pgx.BatchResults) ([][]DeviceType, error)
 
 	// Select many rows of device_type enum values with multiple output columns.
 	FindManyDeviceArrayWithNum(ctx context.Context) ([]FindManyDeviceArrayWithNumRow, error)
-	// FindManyDeviceArrayWithNumBatch enqueues a FindManyDeviceArrayWithNum query into batch to be executed
-	// later by the batch.
-	FindManyDeviceArrayWithNumBatch(batch genericBatch)
-	// FindManyDeviceArrayWithNumScan scans the result of an executed FindManyDeviceArrayWithNumBatch query.
-	FindManyDeviceArrayWithNumScan(results pgx.BatchResults) ([]FindManyDeviceArrayWithNumRow, error)
 
 	// Regression test for https://github.com/jschaf/pggen/issues/23.
 	EnumInsideComposite(ctx context.Context) (Device, error)
-	// EnumInsideCompositeBatch enqueues a EnumInsideComposite query into batch to be executed
-	// later by the batch.
-	EnumInsideCompositeBatch(batch genericBatch)
-	// EnumInsideCompositeScan scans the result of an executed EnumInsideCompositeBatch query.
-	EnumInsideCompositeScan(results pgx.BatchResults) (Device, error)
 }
 
 type DBQuerier struct {
@@ -87,14 +53,6 @@ type genericConn interface {
 	// string. arguments should be referenced positionally from the sql string
 	// as $1, $2, etc.
 	Exec(ctx context.Context, sql string, arguments ...interface{}) (pgconn.CommandTag, error)
-}
-
-// genericBatch batches queries to send in a single network request to a
-// Postgres server. This is usually backed by *pgx.Batch.
-type genericBatch interface {
-	// Queue queues a query to batch b. query can be an SQL query or the name of a
-	// prepared statement. See Queue on *pgx.Batch.
-	Queue(query string, arguments ...interface{})
 }
 
 // NewQuerier creates a DBQuerier that implements Querier. conn is typically
@@ -327,32 +285,6 @@ func (q *DBQuerier) FindAllDevices(ctx context.Context) ([]FindAllDevicesRow, er
 	return items, err
 }
 
-// FindAllDevicesBatch implements Querier.FindAllDevicesBatch.
-func (q *DBQuerier) FindAllDevicesBatch(batch genericBatch) {
-	batch.Queue(findAllDevicesSQL)
-}
-
-// FindAllDevicesScan implements Querier.FindAllDevicesScan.
-func (q *DBQuerier) FindAllDevicesScan(results pgx.BatchResults) ([]FindAllDevicesRow, error) {
-	rows, err := results.Query()
-	if err != nil {
-		return nil, fmt.Errorf("query FindAllDevicesBatch: %w", err)
-	}
-	defer rows.Close()
-	items := []FindAllDevicesRow{}
-	for rows.Next() {
-		var item FindAllDevicesRow
-		if err := rows.Scan(&item.Mac, &item.Type); err != nil {
-			return nil, fmt.Errorf("scan FindAllDevicesBatch row: %w", err)
-		}
-		items = append(items, item)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("close FindAllDevicesBatch rows: %w", err)
-	}
-	return items, err
-}
-
 const insertDeviceSQL = `INSERT INTO device (mac, type)
 VALUES ($1, $2);`
 
@@ -362,20 +294,6 @@ func (q *DBQuerier) InsertDevice(ctx context.Context, mac pgtype.Macaddr, typePg
 	cmdTag, err := q.conn.Exec(ctx, insertDeviceSQL, mac, typePg)
 	if err != nil {
 		return cmdTag, fmt.Errorf("exec query InsertDevice: %w", err)
-	}
-	return cmdTag, err
-}
-
-// InsertDeviceBatch implements Querier.InsertDeviceBatch.
-func (q *DBQuerier) InsertDeviceBatch(batch genericBatch, mac pgtype.Macaddr, typePg DeviceType) {
-	batch.Queue(insertDeviceSQL, mac, typePg)
-}
-
-// InsertDeviceScan implements Querier.InsertDeviceScan.
-func (q *DBQuerier) InsertDeviceScan(results pgx.BatchResults) (pgconn.CommandTag, error) {
-	cmdTag, err := results.Exec()
-	if err != nil {
-		return cmdTag, fmt.Errorf("exec InsertDeviceBatch: %w", err)
 	}
 	return cmdTag, err
 }
@@ -390,25 +308,6 @@ func (q *DBQuerier) FindOneDeviceArray(ctx context.Context) ([]DeviceType, error
 	deviceTypesArray := q.types.newDeviceTypeArray()
 	if err := row.Scan(deviceTypesArray); err != nil {
 		return item, fmt.Errorf("query FindOneDeviceArray: %w", err)
-	}
-	if err := deviceTypesArray.AssignTo(&item); err != nil {
-		return item, fmt.Errorf("assign FindOneDeviceArray row: %w", err)
-	}
-	return item, nil
-}
-
-// FindOneDeviceArrayBatch implements Querier.FindOneDeviceArrayBatch.
-func (q *DBQuerier) FindOneDeviceArrayBatch(batch genericBatch) {
-	batch.Queue(findOneDeviceArraySQL)
-}
-
-// FindOneDeviceArrayScan implements Querier.FindOneDeviceArrayScan.
-func (q *DBQuerier) FindOneDeviceArrayScan(results pgx.BatchResults) ([]DeviceType, error) {
-	row := results.QueryRow()
-	item := []DeviceType{}
-	deviceTypesArray := q.types.newDeviceTypeArray()
-	if err := row.Scan(deviceTypesArray); err != nil {
-		return item, fmt.Errorf("scan FindOneDeviceArrayBatch row: %w", err)
 	}
 	if err := deviceTypesArray.AssignTo(&item); err != nil {
 		return item, fmt.Errorf("assign FindOneDeviceArray row: %w", err)
@@ -442,36 +341,6 @@ func (q *DBQuerier) FindManyDeviceArray(ctx context.Context) ([][]DeviceType, er
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("close FindManyDeviceArray rows: %w", err)
-	}
-	return items, err
-}
-
-// FindManyDeviceArrayBatch implements Querier.FindManyDeviceArrayBatch.
-func (q *DBQuerier) FindManyDeviceArrayBatch(batch genericBatch) {
-	batch.Queue(findManyDeviceArraySQL)
-}
-
-// FindManyDeviceArrayScan implements Querier.FindManyDeviceArrayScan.
-func (q *DBQuerier) FindManyDeviceArrayScan(results pgx.BatchResults) ([][]DeviceType, error) {
-	rows, err := results.Query()
-	if err != nil {
-		return nil, fmt.Errorf("query FindManyDeviceArrayBatch: %w", err)
-	}
-	defer rows.Close()
-	items := [][]DeviceType{}
-	deviceTypesArray := q.types.newDeviceTypeArray()
-	for rows.Next() {
-		var item []DeviceType
-		if err := rows.Scan(deviceTypesArray); err != nil {
-			return nil, fmt.Errorf("scan FindManyDeviceArrayBatch row: %w", err)
-		}
-		if err := deviceTypesArray.AssignTo(&item); err != nil {
-			return nil, fmt.Errorf("assign FindManyDeviceArray row: %w", err)
-		}
-		items = append(items, item)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("close FindManyDeviceArrayBatch rows: %w", err)
 	}
 	return items, err
 }
@@ -511,36 +380,6 @@ func (q *DBQuerier) FindManyDeviceArrayWithNum(ctx context.Context) ([]FindManyD
 	return items, err
 }
 
-// FindManyDeviceArrayWithNumBatch implements Querier.FindManyDeviceArrayWithNumBatch.
-func (q *DBQuerier) FindManyDeviceArrayWithNumBatch(batch genericBatch) {
-	batch.Queue(findManyDeviceArrayWithNumSQL)
-}
-
-// FindManyDeviceArrayWithNumScan implements Querier.FindManyDeviceArrayWithNumScan.
-func (q *DBQuerier) FindManyDeviceArrayWithNumScan(results pgx.BatchResults) ([]FindManyDeviceArrayWithNumRow, error) {
-	rows, err := results.Query()
-	if err != nil {
-		return nil, fmt.Errorf("query FindManyDeviceArrayWithNumBatch: %w", err)
-	}
-	defer rows.Close()
-	items := []FindManyDeviceArrayWithNumRow{}
-	deviceTypesArray := q.types.newDeviceTypeArray()
-	for rows.Next() {
-		var item FindManyDeviceArrayWithNumRow
-		if err := rows.Scan(&item.Num, deviceTypesArray); err != nil {
-			return nil, fmt.Errorf("scan FindManyDeviceArrayWithNumBatch row: %w", err)
-		}
-		if err := deviceTypesArray.AssignTo(&item.DeviceTypes); err != nil {
-			return nil, fmt.Errorf("assign FindManyDeviceArrayWithNum row: %w", err)
-		}
-		items = append(items, item)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("close FindManyDeviceArrayWithNumBatch rows: %w", err)
-	}
-	return items, err
-}
-
 const enumInsideCompositeSQL = `SELECT ROW('08:00:2b:01:02:03'::macaddr, 'phone'::device_type) ::device;`
 
 // EnumInsideComposite implements Querier.EnumInsideComposite.
@@ -551,25 +390,6 @@ func (q *DBQuerier) EnumInsideComposite(ctx context.Context) (Device, error) {
 	rowRow := q.types.newDevice()
 	if err := row.Scan(rowRow); err != nil {
 		return item, fmt.Errorf("query EnumInsideComposite: %w", err)
-	}
-	if err := rowRow.AssignTo(&item); err != nil {
-		return item, fmt.Errorf("assign EnumInsideComposite row: %w", err)
-	}
-	return item, nil
-}
-
-// EnumInsideCompositeBatch implements Querier.EnumInsideCompositeBatch.
-func (q *DBQuerier) EnumInsideCompositeBatch(batch genericBatch) {
-	batch.Queue(enumInsideCompositeSQL)
-}
-
-// EnumInsideCompositeScan implements Querier.EnumInsideCompositeScan.
-func (q *DBQuerier) EnumInsideCompositeScan(results pgx.BatchResults) (Device, error) {
-	row := results.QueryRow()
-	var item Device
-	rowRow := q.types.newDevice()
-	if err := row.Scan(rowRow); err != nil {
-		return item, fmt.Errorf("scan EnumInsideCompositeBatch row: %w", err)
 	}
 	if err := rowRow.AssignTo(&item); err != nil {
 		return item, fmt.Errorf("assign EnumInsideComposite row: %w", err)

--- a/example/enums/query.sql_test.go
+++ b/example/enums/query.sql_test.go
@@ -3,8 +3,6 @@ package enums
 import (
 	"context"
 	"github.com/jackc/pgtype"
-	"github.com/jackc/pgx/v4"
-	"github.com/jschaf/pggen/internal/errs"
 	"github.com/jschaf/pggen/internal/pgtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -26,21 +24,6 @@ func TestNewQuerier_FindAllDevices(t *testing.T) {
 
 	t.Run("FindAllDevices", func(t *testing.T) {
 		devices, err := q.FindAllDevices(ctx)
-		require.NoError(t, err)
-		assert.Equal(t,
-			[]FindAllDevicesRow{
-				{Mac: pgtype.Macaddr{Addr: mac, Status: pgtype.Present}, Type: DeviceTypeIot},
-			},
-			devices,
-		)
-	})
-
-	t.Run("FindAllDevicesScan", func(t *testing.T) {
-		batch := &pgx.Batch{}
-		q.FindAllDevicesBatch(batch)
-		results := conn.SendBatch(context.Background(), batch)
-		defer errs.CaptureT(t, results.Close, "close batch results")
-		devices, err := q.FindAllDevicesScan(results)
 		require.NoError(t, err)
 		assert.Equal(t,
 			[]FindAllDevicesRow{
@@ -73,16 +56,6 @@ func TestNewQuerier_FindOneDeviceArray(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, allDeviceTypes, devices)
 	})
-
-	t.Run("FindOneDeviceArrayBatch", func(t *testing.T) {
-		batch := &pgx.Batch{}
-		q.FindOneDeviceArrayBatch(batch)
-		results := conn.SendBatch(context.Background(), batch)
-		defer errs.CaptureT(t, results.Close, "close batch results")
-		devices, err := q.FindOneDeviceArrayScan(results)
-		require.NoError(t, err)
-		assert.Equal(t, allDeviceTypes, devices)
-	})
 }
 
 func TestNewQuerier_FindManyDeviceArray(t *testing.T) {
@@ -95,16 +68,6 @@ func TestNewQuerier_FindManyDeviceArray(t *testing.T) {
 
 	t.Run("FindManyDeviceArray", func(t *testing.T) {
 		devices, err := q.FindManyDeviceArray(ctx)
-		require.NoError(t, err)
-		assert.Equal(t, [][]DeviceType{allDeviceTypes[3:], allDeviceTypes}, devices)
-	})
-
-	t.Run("FindManyDeviceArrayBatch", func(t *testing.T) {
-		batch := &pgx.Batch{}
-		q.FindManyDeviceArrayBatch(batch)
-		results := conn.SendBatch(context.Background(), batch)
-		defer errs.CaptureT(t, results.Close, "close batch results")
-		devices, err := q.FindManyDeviceArrayScan(results)
 		require.NoError(t, err)
 		assert.Equal(t, [][]DeviceType{allDeviceTypes[3:], allDeviceTypes}, devices)
 	})
@@ -127,19 +90,6 @@ func TestNewQuerier_FindManyDeviceArrayWithNum(t *testing.T) {
 			{Num: &two, DeviceTypes: allDeviceTypes},
 		}, devices)
 	})
-
-	t.Run("FindManyDeviceArrayWithNumBatch", func(t *testing.T) {
-		batch := &pgx.Batch{}
-		q.FindManyDeviceArrayWithNumBatch(batch)
-		results := conn.SendBatch(context.Background(), batch)
-		defer errs.CaptureT(t, results.Close, "close batch results")
-		devices, err := q.FindManyDeviceArrayWithNumScan(results)
-		require.NoError(t, err)
-		assert.Equal(t, []FindManyDeviceArrayWithNumRow{
-			{Num: &one, DeviceTypes: allDeviceTypes[3:]},
-			{Num: &two, DeviceTypes: allDeviceTypes},
-		}, devices)
-	})
 }
 
 func TestNewQuerier_EnumInsideComposite(t *testing.T) {
@@ -153,19 +103,6 @@ func TestNewQuerier_EnumInsideComposite(t *testing.T) {
 
 	t.Run("EnumInsideComposite", func(t *testing.T) {
 		device, err := q.EnumInsideComposite(ctx)
-		require.NoError(t, err)
-		assert.Equal(t,
-			Device{Mac: pgtype.Macaddr{Addr: mac, Status: pgtype.Present}, Type: DeviceTypePhone},
-			device,
-		)
-	})
-
-	t.Run("EnumInsideCompositeBatch", func(t *testing.T) {
-		batch := &pgx.Batch{}
-		q.EnumInsideCompositeBatch(batch)
-		results := conn.SendBatch(context.Background(), batch)
-		defer errs.CaptureT(t, results.Close, "close batch results")
-		device, err := q.EnumInsideCompositeScan(results)
 		require.NoError(t, err)
 		assert.Equal(t,
 			Device{Mac: pgtype.Macaddr{Addr: mac, Status: pgtype.Present}, Type: DeviceTypePhone},

--- a/example/erp/order/customer.sql_test.go
+++ b/example/erp/order/customer.sql_test.go
@@ -99,22 +99,8 @@ func TestNewQuerier_QuerierMatchesDBQuerier(t *testing.T) {
 	var q Querier = NewQuerier(nil)
 	// Really a compile-time check.
 	require.NotNil(t, q.FindOrdersByCustomer)
-	require.NotNil(t, q.FindOrdersByCustomerBatch)
-	require.NotNil(t, q.FindOrdersByCustomerScan)
-
 	require.NotNil(t, q.FindProductsInOrder)
-	require.NotNil(t, q.FindProductsInOrderBatch)
-	require.NotNil(t, q.FindProductsInOrderScan)
-
 	require.NotNil(t, q.InsertOrder)
-	require.NotNil(t, q.InsertOrderBatch)
-	require.NotNil(t, q.InsertOrderScan)
-
 	require.NotNil(t, q.FindOrdersByPrice)
-	require.NotNil(t, q.FindOrdersByPriceBatch)
-	require.NotNil(t, q.FindOrdersByPriceScan)
-
 	require.NotNil(t, q.FindOrdersMRR)
-	require.NotNil(t, q.FindOrdersMRRBatch)
-	require.NotNil(t, q.FindOrdersMRRScan)
 }

--- a/example/go_pointer_types/query.sql.go
+++ b/example/go_pointer_types/query.sql.go
@@ -11,52 +11,18 @@ import (
 )
 
 // Querier is a typesafe Go interface backed by SQL queries.
-//
-// Methods ending with Batch enqueue a query to run later in a pgx.Batch. After
-// calling SendBatch on pgx.Conn, pgxpool.Pool, or pgx.Tx, use the Scan methods
-// to parse the results.
 type Querier interface {
 	GenSeries1(ctx context.Context) (*int, error)
-	// GenSeries1Batch enqueues a GenSeries1 query into batch to be executed
-	// later by the batch.
-	GenSeries1Batch(batch genericBatch)
-	// GenSeries1Scan scans the result of an executed GenSeries1Batch query.
-	GenSeries1Scan(results pgx.BatchResults) (*int, error)
 
 	GenSeries(ctx context.Context) ([]*int, error)
-	// GenSeriesBatch enqueues a GenSeries query into batch to be executed
-	// later by the batch.
-	GenSeriesBatch(batch genericBatch)
-	// GenSeriesScan scans the result of an executed GenSeriesBatch query.
-	GenSeriesScan(results pgx.BatchResults) ([]*int, error)
 
 	GenSeriesArr1(ctx context.Context) ([]int, error)
-	// GenSeriesArr1Batch enqueues a GenSeriesArr1 query into batch to be executed
-	// later by the batch.
-	GenSeriesArr1Batch(batch genericBatch)
-	// GenSeriesArr1Scan scans the result of an executed GenSeriesArr1Batch query.
-	GenSeriesArr1Scan(results pgx.BatchResults) ([]int, error)
 
 	GenSeriesArr(ctx context.Context) ([][]int, error)
-	// GenSeriesArrBatch enqueues a GenSeriesArr query into batch to be executed
-	// later by the batch.
-	GenSeriesArrBatch(batch genericBatch)
-	// GenSeriesArrScan scans the result of an executed GenSeriesArrBatch query.
-	GenSeriesArrScan(results pgx.BatchResults) ([][]int, error)
 
 	GenSeriesStr1(ctx context.Context) (*string, error)
-	// GenSeriesStr1Batch enqueues a GenSeriesStr1 query into batch to be executed
-	// later by the batch.
-	GenSeriesStr1Batch(batch genericBatch)
-	// GenSeriesStr1Scan scans the result of an executed GenSeriesStr1Batch query.
-	GenSeriesStr1Scan(results pgx.BatchResults) (*string, error)
 
 	GenSeriesStr(ctx context.Context) ([]*string, error)
-	// GenSeriesStrBatch enqueues a GenSeriesStr query into batch to be executed
-	// later by the batch.
-	GenSeriesStrBatch(batch genericBatch)
-	// GenSeriesStrScan scans the result of an executed GenSeriesStrBatch query.
-	GenSeriesStrScan(results pgx.BatchResults) ([]*string, error)
 }
 
 type DBQuerier struct {
@@ -83,14 +49,6 @@ type genericConn interface {
 	// string. arguments should be referenced positionally from the sql string
 	// as $1, $2, etc.
 	Exec(ctx context.Context, sql string, arguments ...interface{}) (pgconn.CommandTag, error)
-}
-
-// genericBatch batches queries to send in a single network request to a
-// Postgres server. This is usually backed by *pgx.Batch.
-type genericBatch interface {
-	// Queue queues a query to batch b. query can be an SQL query or the name of a
-	// prepared statement. See Queue on *pgx.Batch.
-	Queue(query string, arguments ...interface{})
 }
 
 // NewQuerier creates a DBQuerier that implements Querier. conn is typically
@@ -205,21 +163,6 @@ func (q *DBQuerier) GenSeries1(ctx context.Context) (*int, error) {
 	return item, nil
 }
 
-// GenSeries1Batch implements Querier.GenSeries1Batch.
-func (q *DBQuerier) GenSeries1Batch(batch genericBatch) {
-	batch.Queue(genSeries1SQL)
-}
-
-// GenSeries1Scan implements Querier.GenSeries1Scan.
-func (q *DBQuerier) GenSeries1Scan(results pgx.BatchResults) (*int, error) {
-	row := results.QueryRow()
-	var item *int
-	if err := row.Scan(&item); err != nil {
-		return item, fmt.Errorf("scan GenSeries1Batch row: %w", err)
-	}
-	return item, nil
-}
-
 const genSeriesSQL = `SELECT n
 FROM generate_series(0, 2) n;`
 
@@ -245,32 +188,6 @@ func (q *DBQuerier) GenSeries(ctx context.Context) ([]*int, error) {
 	return items, err
 }
 
-// GenSeriesBatch implements Querier.GenSeriesBatch.
-func (q *DBQuerier) GenSeriesBatch(batch genericBatch) {
-	batch.Queue(genSeriesSQL)
-}
-
-// GenSeriesScan implements Querier.GenSeriesScan.
-func (q *DBQuerier) GenSeriesScan(results pgx.BatchResults) ([]*int, error) {
-	rows, err := results.Query()
-	if err != nil {
-		return nil, fmt.Errorf("query GenSeriesBatch: %w", err)
-	}
-	defer rows.Close()
-	items := []*int{}
-	for rows.Next() {
-		var item int
-		if err := rows.Scan(&item); err != nil {
-			return nil, fmt.Errorf("scan GenSeriesBatch row: %w", err)
-		}
-		items = append(items, &item)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("close GenSeriesBatch rows: %w", err)
-	}
-	return items, err
-}
-
 const genSeriesArr1SQL = `SELECT array_agg(n)
 FROM generate_series(0, 2) n;`
 
@@ -281,21 +198,6 @@ func (q *DBQuerier) GenSeriesArr1(ctx context.Context) ([]int, error) {
 	item := []int{}
 	if err := row.Scan(&item); err != nil {
 		return item, fmt.Errorf("query GenSeriesArr1: %w", err)
-	}
-	return item, nil
-}
-
-// GenSeriesArr1Batch implements Querier.GenSeriesArr1Batch.
-func (q *DBQuerier) GenSeriesArr1Batch(batch genericBatch) {
-	batch.Queue(genSeriesArr1SQL)
-}
-
-// GenSeriesArr1Scan implements Querier.GenSeriesArr1Scan.
-func (q *DBQuerier) GenSeriesArr1Scan(results pgx.BatchResults) ([]int, error) {
-	row := results.QueryRow()
-	item := []int{}
-	if err := row.Scan(&item); err != nil {
-		return item, fmt.Errorf("scan GenSeriesArr1Batch row: %w", err)
 	}
 	return item, nil
 }
@@ -325,32 +227,6 @@ func (q *DBQuerier) GenSeriesArr(ctx context.Context) ([][]int, error) {
 	return items, err
 }
 
-// GenSeriesArrBatch implements Querier.GenSeriesArrBatch.
-func (q *DBQuerier) GenSeriesArrBatch(batch genericBatch) {
-	batch.Queue(genSeriesArrSQL)
-}
-
-// GenSeriesArrScan implements Querier.GenSeriesArrScan.
-func (q *DBQuerier) GenSeriesArrScan(results pgx.BatchResults) ([][]int, error) {
-	rows, err := results.Query()
-	if err != nil {
-		return nil, fmt.Errorf("query GenSeriesArrBatch: %w", err)
-	}
-	defer rows.Close()
-	items := [][]int{}
-	for rows.Next() {
-		var item []int
-		if err := rows.Scan(&item); err != nil {
-			return nil, fmt.Errorf("scan GenSeriesArrBatch row: %w", err)
-		}
-		items = append(items, item)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("close GenSeriesArrBatch rows: %w", err)
-	}
-	return items, err
-}
-
 const genSeriesStr1SQL = `SELECT n::text
 FROM generate_series(0, 2) n
 LIMIT 1;`
@@ -362,21 +238,6 @@ func (q *DBQuerier) GenSeriesStr1(ctx context.Context) (*string, error) {
 	var item *string
 	if err := row.Scan(&item); err != nil {
 		return item, fmt.Errorf("query GenSeriesStr1: %w", err)
-	}
-	return item, nil
-}
-
-// GenSeriesStr1Batch implements Querier.GenSeriesStr1Batch.
-func (q *DBQuerier) GenSeriesStr1Batch(batch genericBatch) {
-	batch.Queue(genSeriesStr1SQL)
-}
-
-// GenSeriesStr1Scan implements Querier.GenSeriesStr1Scan.
-func (q *DBQuerier) GenSeriesStr1Scan(results pgx.BatchResults) (*string, error) {
-	row := results.QueryRow()
-	var item *string
-	if err := row.Scan(&item); err != nil {
-		return item, fmt.Errorf("scan GenSeriesStr1Batch row: %w", err)
 	}
 	return item, nil
 }
@@ -402,32 +263,6 @@ func (q *DBQuerier) GenSeriesStr(ctx context.Context) ([]*string, error) {
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("close GenSeriesStr rows: %w", err)
-	}
-	return items, err
-}
-
-// GenSeriesStrBatch implements Querier.GenSeriesStrBatch.
-func (q *DBQuerier) GenSeriesStrBatch(batch genericBatch) {
-	batch.Queue(genSeriesStrSQL)
-}
-
-// GenSeriesStrScan implements Querier.GenSeriesStrScan.
-func (q *DBQuerier) GenSeriesStrScan(results pgx.BatchResults) ([]*string, error) {
-	rows, err := results.Query()
-	if err != nil {
-		return nil, fmt.Errorf("query GenSeriesStrBatch: %w", err)
-	}
-	defer rows.Close()
-	items := []*string{}
-	for rows.Next() {
-		var item string
-		if err := rows.Scan(&item); err != nil {
-			return nil, fmt.Errorf("scan GenSeriesStrBatch row: %w", err)
-		}
-		items = append(items, &item)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("close GenSeriesStrBatch rows: %w", err)
 	}
 	return items, err
 }

--- a/example/go_pointer_types/query.sql_test.go
+++ b/example/go_pointer_types/query.sql_test.go
@@ -2,8 +2,6 @@ package go_pointer_types
 
 import (
 	"context"
-	"github.com/jackc/pgx/v4"
-	"github.com/jschaf/pggen/internal/errs"
 	"github.com/jschaf/pggen/internal/pgtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -19,17 +17,6 @@ func TestQuerier_GenSeries1(t *testing.T) {
 
 	t.Run("GenSeries1", func(t *testing.T) {
 		got, err := q.GenSeries1(ctx)
-		require.NoError(t, err)
-		zero := 0
-		assert.Equal(t, &zero, got)
-	})
-
-	t.Run("GenSeries1Batch", func(t *testing.T) {
-		batch := &pgx.Batch{}
-		q.GenSeries1Batch(batch)
-		results := conn.SendBatch(ctx, batch)
-		defer errs.CaptureT(t, results.Close, "close batch")
-		got, err := q.GenSeries1Scan(results)
 		require.NoError(t, err)
 		zero := 0
 		assert.Equal(t, &zero, got)
@@ -51,17 +38,6 @@ func TestQuerier_GenSeries(t *testing.T) {
 		zero, one, two := 0, 1, 2
 		assert.Equal(t, []*int{&zero, &one, &two}, got)
 	})
-
-	t.Run("GenSeriesBatch", func(t *testing.T) {
-		batch := &pgx.Batch{}
-		q.GenSeriesBatch(batch)
-		results := conn.SendBatch(ctx, batch)
-		defer errs.CaptureT(t, results.Close, "close batch")
-		got, err := q.GenSeriesScan(results)
-		require.NoError(t, err)
-		zero, one, two := 0, 1, 2
-		assert.Equal(t, []*int{&zero, &one, &two}, got)
-	})
 }
 
 func TestQuerier_GenSeriesArr1(t *testing.T) {
@@ -76,18 +52,6 @@ func TestQuerier_GenSeriesArr1(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, []int{0, 1, 2}, got)
 	})
-
-	t.Run("GenSeriesArr1Batch", func(t *testing.T) {
-		batch := &pgx.Batch{}
-		q.GenSeriesArr1Batch(batch)
-		results := conn.SendBatch(ctx, batch)
-		defer errs.CaptureT(t, results.Close, "close batch")
-		got, err := q.GenSeriesArr1Scan(results)
-		if err != nil {
-			t.Fatal(err)
-		}
-		assert.Equal(t, []int{0, 1, 2}, got)
-	})
 }
 
 func TestQuerier_GenSeriesArr(t *testing.T) {
@@ -100,16 +64,6 @@ func TestQuerier_GenSeriesArr(t *testing.T) {
 	t.Run("GenSeriesArr", func(t *testing.T) {
 		got, err := q.GenSeriesArr(ctx)
 		require.NoError(t, err)
-		assert.Equal(t, [][]int{{0, 1, 2}}, got)
-	})
-
-	t.Run("GenSeriesArrBatch", func(t *testing.T) {
-		batch := &pgx.Batch{}
-		q.GenSeriesArrBatch(batch)
-		results := conn.SendBatch(ctx, batch)
-		defer errs.CaptureT(t, results.Close, "close batch")
-		got, err := q.GenSeriesArrScan(results)
-		require.Nil(t, err)
 		assert.Equal(t, [][]int{{0, 1, 2}}, got)
 	})
 }
@@ -128,30 +82,8 @@ func TestQuerier_GenSeriesStr(t *testing.T) {
 		assert.Equal(t, &zero, got)
 	})
 
-	t.Run("GenSeriesStr1Batch", func(t *testing.T) {
-		batch := &pgx.Batch{}
-		q.GenSeriesStr1Batch(batch)
-		results := conn.SendBatch(ctx, batch)
-		defer errs.CaptureT(t, results.Close, "close batch")
-		got, err := q.GenSeriesStr1Scan(results)
-		require.NoError(t, err)
-		zero := "0"
-		assert.Equal(t, &zero, got)
-	})
-
 	t.Run("GenSeriesStr", func(t *testing.T) {
 		got, err := q.GenSeriesStr(ctx)
-		require.NoError(t, err)
-		zero, one, two := "0", "1", "2"
-		assert.Equal(t, []*string{&zero, &one, &two}, got)
-	})
-
-	t.Run("GenSeriesStrBatch", func(t *testing.T) {
-		batch := &pgx.Batch{}
-		q.GenSeriesStrBatch(batch)
-		results := conn.SendBatch(ctx, batch)
-		defer errs.CaptureT(t, results.Close, "close batch")
-		got, err := q.GenSeriesStrScan(results)
 		require.NoError(t, err)
 		zero, one, two := "0", "1", "2"
 		assert.Equal(t, []*string{&zero, &one, &two}, got)

--- a/example/inline_param_count/inline0/query.sql.go
+++ b/example/inline_param_count/inline0/query.sql.go
@@ -11,42 +11,18 @@ import (
 )
 
 // Querier is a typesafe Go interface backed by SQL queries.
-//
-// Methods ending with Batch enqueue a query to run later in a pgx.Batch. After
-// calling SendBatch on pgx.Conn, pgxpool.Pool, or pgx.Tx, use the Scan methods
-// to parse the results.
 type Querier interface {
 	// CountAuthors returns the number of authors (zero params).
 	CountAuthors(ctx context.Context) (*int, error)
-	// CountAuthorsBatch enqueues a CountAuthors query into batch to be executed
-	// later by the batch.
-	CountAuthorsBatch(batch genericBatch)
-	// CountAuthorsScan scans the result of an executed CountAuthorsBatch query.
-	CountAuthorsScan(results pgx.BatchResults) (*int, error)
 
 	// FindAuthorById finds one (or zero) authors by ID (one param).
 	FindAuthorByID(ctx context.Context, params FindAuthorByIDParams) (FindAuthorByIDRow, error)
-	// FindAuthorByIDBatch enqueues a FindAuthorByID query into batch to be executed
-	// later by the batch.
-	FindAuthorByIDBatch(batch genericBatch, params FindAuthorByIDParams)
-	// FindAuthorByIDScan scans the result of an executed FindAuthorByIDBatch query.
-	FindAuthorByIDScan(results pgx.BatchResults) (FindAuthorByIDRow, error)
 
 	// InsertAuthor inserts an author by name and returns the ID (two params).
 	InsertAuthor(ctx context.Context, params InsertAuthorParams) (int32, error)
-	// InsertAuthorBatch enqueues a InsertAuthor query into batch to be executed
-	// later by the batch.
-	InsertAuthorBatch(batch genericBatch, params InsertAuthorParams)
-	// InsertAuthorScan scans the result of an executed InsertAuthorBatch query.
-	InsertAuthorScan(results pgx.BatchResults) (int32, error)
 
 	// DeleteAuthorsByFullName deletes authors by the full name (three params).
 	DeleteAuthorsByFullName(ctx context.Context, params DeleteAuthorsByFullNameParams) (pgconn.CommandTag, error)
-	// DeleteAuthorsByFullNameBatch enqueues a DeleteAuthorsByFullName query into batch to be executed
-	// later by the batch.
-	DeleteAuthorsByFullNameBatch(batch genericBatch, params DeleteAuthorsByFullNameParams)
-	// DeleteAuthorsByFullNameScan scans the result of an executed DeleteAuthorsByFullNameBatch query.
-	DeleteAuthorsByFullNameScan(results pgx.BatchResults) (pgconn.CommandTag, error)
 }
 
 type DBQuerier struct {
@@ -73,14 +49,6 @@ type genericConn interface {
 	// string. arguments should be referenced positionally from the sql string
 	// as $1, $2, etc.
 	Exec(ctx context.Context, sql string, arguments ...interface{}) (pgconn.CommandTag, error)
-}
-
-// genericBatch batches queries to send in a single network request to a
-// Postgres server. This is usually backed by *pgx.Batch.
-type genericBatch interface {
-	// Queue queues a query to batch b. query can be an SQL query or the name of a
-	// prepared statement. See Queue on *pgx.Batch.
-	Queue(query string, arguments ...interface{})
 }
 
 // NewQuerier creates a DBQuerier that implements Querier. conn is typically
@@ -187,21 +155,6 @@ func (q *DBQuerier) CountAuthors(ctx context.Context) (*int, error) {
 	return item, nil
 }
 
-// CountAuthorsBatch implements Querier.CountAuthorsBatch.
-func (q *DBQuerier) CountAuthorsBatch(batch genericBatch) {
-	batch.Queue(countAuthorsSQL)
-}
-
-// CountAuthorsScan implements Querier.CountAuthorsScan.
-func (q *DBQuerier) CountAuthorsScan(results pgx.BatchResults) (*int, error) {
-	row := results.QueryRow()
-	var item *int
-	if err := row.Scan(&item); err != nil {
-		return item, fmt.Errorf("scan CountAuthorsBatch row: %w", err)
-	}
-	return item, nil
-}
-
 const findAuthorByIDSQL = `SELECT * FROM author WHERE author_id = $1;`
 
 type FindAuthorByIDParams struct {
@@ -226,21 +179,6 @@ func (q *DBQuerier) FindAuthorByID(ctx context.Context, params FindAuthorByIDPar
 	return item, nil
 }
 
-// FindAuthorByIDBatch implements Querier.FindAuthorByIDBatch.
-func (q *DBQuerier) FindAuthorByIDBatch(batch genericBatch, params FindAuthorByIDParams) {
-	batch.Queue(findAuthorByIDSQL, params.AuthorID)
-}
-
-// FindAuthorByIDScan implements Querier.FindAuthorByIDScan.
-func (q *DBQuerier) FindAuthorByIDScan(results pgx.BatchResults) (FindAuthorByIDRow, error) {
-	row := results.QueryRow()
-	var item FindAuthorByIDRow
-	if err := row.Scan(&item.AuthorID, &item.FirstName, &item.LastName, &item.Suffix); err != nil {
-		return item, fmt.Errorf("scan FindAuthorByIDBatch row: %w", err)
-	}
-	return item, nil
-}
-
 const insertAuthorSQL = `INSERT INTO author (first_name, last_name)
 VALUES ($1, $2)
 RETURNING author_id;`
@@ -257,21 +195,6 @@ func (q *DBQuerier) InsertAuthor(ctx context.Context, params InsertAuthorParams)
 	var item int32
 	if err := row.Scan(&item); err != nil {
 		return item, fmt.Errorf("query InsertAuthor: %w", err)
-	}
-	return item, nil
-}
-
-// InsertAuthorBatch implements Querier.InsertAuthorBatch.
-func (q *DBQuerier) InsertAuthorBatch(batch genericBatch, params InsertAuthorParams) {
-	batch.Queue(insertAuthorSQL, params.FirstName, params.LastName)
-}
-
-// InsertAuthorScan implements Querier.InsertAuthorScan.
-func (q *DBQuerier) InsertAuthorScan(results pgx.BatchResults) (int32, error) {
-	row := results.QueryRow()
-	var item int32
-	if err := row.Scan(&item); err != nil {
-		return item, fmt.Errorf("scan InsertAuthorBatch row: %w", err)
 	}
 	return item, nil
 }
@@ -294,20 +217,6 @@ func (q *DBQuerier) DeleteAuthorsByFullName(ctx context.Context, params DeleteAu
 	cmdTag, err := q.conn.Exec(ctx, deleteAuthorsByFullNameSQL, params.FirstName, params.LastName, params.Suffix)
 	if err != nil {
 		return cmdTag, fmt.Errorf("exec query DeleteAuthorsByFullName: %w", err)
-	}
-	return cmdTag, err
-}
-
-// DeleteAuthorsByFullNameBatch implements Querier.DeleteAuthorsByFullNameBatch.
-func (q *DBQuerier) DeleteAuthorsByFullNameBatch(batch genericBatch, params DeleteAuthorsByFullNameParams) {
-	batch.Queue(deleteAuthorsByFullNameSQL, params.FirstName, params.LastName, params.Suffix)
-}
-
-// DeleteAuthorsByFullNameScan implements Querier.DeleteAuthorsByFullNameScan.
-func (q *DBQuerier) DeleteAuthorsByFullNameScan(results pgx.BatchResults) (pgconn.CommandTag, error) {
-	cmdTag, err := results.Exec()
-	if err != nil {
-		return cmdTag, fmt.Errorf("exec DeleteAuthorsByFullNameBatch: %w", err)
 	}
 	return cmdTag, err
 }

--- a/example/inline_param_count/inline0/query.sql_test.go
+++ b/example/inline_param_count/inline0/query.sql_test.go
@@ -3,7 +3,6 @@ package inline0
 import (
 	"context"
 	"errors"
-	"github.com/jschaf/pggen/internal/errs"
 	"github.com/stretchr/testify/require"
 	"testing"
 
@@ -44,21 +43,6 @@ func TestNewQuerier_FindAuthorByID(t *testing.T) {
 		if !errors.Is(err, pgx.ErrNoRows) {
 			t.Fatalf("expected no rows error to wrap pgx.ErrNoRows; got %s", err)
 		}
-	})
-
-	t.Run("FindAuthorByIDBatch", func(t *testing.T) {
-		batch := &pgx.Batch{}
-		q.FindAuthorByIDBatch(batch, FindAuthorByIDParams{AuthorID: adamsID})
-		results := conn.SendBatch(context.Background(), batch)
-		defer errs.CaptureT(t, results.Close, "close batch results")
-		authors, err := q.FindAuthorByIDScan(results)
-		require.NoError(t, err)
-		assert.Equal(t, FindAuthorByIDRow{
-			AuthorID:  adamsID,
-			FirstName: "john",
-			LastName:  "adams",
-			Suffix:    nil,
-		}, authors)
 	})
 }
 

--- a/example/inline_param_count/inline1/query.sql.go
+++ b/example/inline_param_count/inline1/query.sql.go
@@ -11,42 +11,18 @@ import (
 )
 
 // Querier is a typesafe Go interface backed by SQL queries.
-//
-// Methods ending with Batch enqueue a query to run later in a pgx.Batch. After
-// calling SendBatch on pgx.Conn, pgxpool.Pool, or pgx.Tx, use the Scan methods
-// to parse the results.
 type Querier interface {
 	// CountAuthors returns the number of authors (zero params).
 	CountAuthors(ctx context.Context) (*int, error)
-	// CountAuthorsBatch enqueues a CountAuthors query into batch to be executed
-	// later by the batch.
-	CountAuthorsBatch(batch genericBatch)
-	// CountAuthorsScan scans the result of an executed CountAuthorsBatch query.
-	CountAuthorsScan(results pgx.BatchResults) (*int, error)
 
 	// FindAuthorById finds one (or zero) authors by ID (one param).
 	FindAuthorByID(ctx context.Context, authorID int32) (FindAuthorByIDRow, error)
-	// FindAuthorByIDBatch enqueues a FindAuthorByID query into batch to be executed
-	// later by the batch.
-	FindAuthorByIDBatch(batch genericBatch, authorID int32)
-	// FindAuthorByIDScan scans the result of an executed FindAuthorByIDBatch query.
-	FindAuthorByIDScan(results pgx.BatchResults) (FindAuthorByIDRow, error)
 
 	// InsertAuthor inserts an author by name and returns the ID (two params).
 	InsertAuthor(ctx context.Context, params InsertAuthorParams) (int32, error)
-	// InsertAuthorBatch enqueues a InsertAuthor query into batch to be executed
-	// later by the batch.
-	InsertAuthorBatch(batch genericBatch, params InsertAuthorParams)
-	// InsertAuthorScan scans the result of an executed InsertAuthorBatch query.
-	InsertAuthorScan(results pgx.BatchResults) (int32, error)
 
 	// DeleteAuthorsByFullName deletes authors by the full name (three params).
 	DeleteAuthorsByFullName(ctx context.Context, params DeleteAuthorsByFullNameParams) (pgconn.CommandTag, error)
-	// DeleteAuthorsByFullNameBatch enqueues a DeleteAuthorsByFullName query into batch to be executed
-	// later by the batch.
-	DeleteAuthorsByFullNameBatch(batch genericBatch, params DeleteAuthorsByFullNameParams)
-	// DeleteAuthorsByFullNameScan scans the result of an executed DeleteAuthorsByFullNameBatch query.
-	DeleteAuthorsByFullNameScan(results pgx.BatchResults) (pgconn.CommandTag, error)
 }
 
 type DBQuerier struct {
@@ -73,14 +49,6 @@ type genericConn interface {
 	// string. arguments should be referenced positionally from the sql string
 	// as $1, $2, etc.
 	Exec(ctx context.Context, sql string, arguments ...interface{}) (pgconn.CommandTag, error)
-}
-
-// genericBatch batches queries to send in a single network request to a
-// Postgres server. This is usually backed by *pgx.Batch.
-type genericBatch interface {
-	// Queue queues a query to batch b. query can be an SQL query or the name of a
-	// prepared statement. See Queue on *pgx.Batch.
-	Queue(query string, arguments ...interface{})
 }
 
 // NewQuerier creates a DBQuerier that implements Querier. conn is typically
@@ -187,21 +155,6 @@ func (q *DBQuerier) CountAuthors(ctx context.Context) (*int, error) {
 	return item, nil
 }
 
-// CountAuthorsBatch implements Querier.CountAuthorsBatch.
-func (q *DBQuerier) CountAuthorsBatch(batch genericBatch) {
-	batch.Queue(countAuthorsSQL)
-}
-
-// CountAuthorsScan implements Querier.CountAuthorsScan.
-func (q *DBQuerier) CountAuthorsScan(results pgx.BatchResults) (*int, error) {
-	row := results.QueryRow()
-	var item *int
-	if err := row.Scan(&item); err != nil {
-		return item, fmt.Errorf("scan CountAuthorsBatch row: %w", err)
-	}
-	return item, nil
-}
-
 const findAuthorByIDSQL = `SELECT * FROM author WHERE author_id = $1;`
 
 type FindAuthorByIDRow struct {
@@ -218,21 +171,6 @@ func (q *DBQuerier) FindAuthorByID(ctx context.Context, authorID int32) (FindAut
 	var item FindAuthorByIDRow
 	if err := row.Scan(&item.AuthorID, &item.FirstName, &item.LastName, &item.Suffix); err != nil {
 		return item, fmt.Errorf("query FindAuthorByID: %w", err)
-	}
-	return item, nil
-}
-
-// FindAuthorByIDBatch implements Querier.FindAuthorByIDBatch.
-func (q *DBQuerier) FindAuthorByIDBatch(batch genericBatch, authorID int32) {
-	batch.Queue(findAuthorByIDSQL, authorID)
-}
-
-// FindAuthorByIDScan implements Querier.FindAuthorByIDScan.
-func (q *DBQuerier) FindAuthorByIDScan(results pgx.BatchResults) (FindAuthorByIDRow, error) {
-	row := results.QueryRow()
-	var item FindAuthorByIDRow
-	if err := row.Scan(&item.AuthorID, &item.FirstName, &item.LastName, &item.Suffix); err != nil {
-		return item, fmt.Errorf("scan FindAuthorByIDBatch row: %w", err)
 	}
 	return item, nil
 }
@@ -257,21 +195,6 @@ func (q *DBQuerier) InsertAuthor(ctx context.Context, params InsertAuthorParams)
 	return item, nil
 }
 
-// InsertAuthorBatch implements Querier.InsertAuthorBatch.
-func (q *DBQuerier) InsertAuthorBatch(batch genericBatch, params InsertAuthorParams) {
-	batch.Queue(insertAuthorSQL, params.FirstName, params.LastName)
-}
-
-// InsertAuthorScan implements Querier.InsertAuthorScan.
-func (q *DBQuerier) InsertAuthorScan(results pgx.BatchResults) (int32, error) {
-	row := results.QueryRow()
-	var item int32
-	if err := row.Scan(&item); err != nil {
-		return item, fmt.Errorf("scan InsertAuthorBatch row: %w", err)
-	}
-	return item, nil
-}
-
 const deleteAuthorsByFullNameSQL = `DELETE
 FROM author
 WHERE first_name = $1
@@ -290,20 +213,6 @@ func (q *DBQuerier) DeleteAuthorsByFullName(ctx context.Context, params DeleteAu
 	cmdTag, err := q.conn.Exec(ctx, deleteAuthorsByFullNameSQL, params.FirstName, params.LastName, params.Suffix)
 	if err != nil {
 		return cmdTag, fmt.Errorf("exec query DeleteAuthorsByFullName: %w", err)
-	}
-	return cmdTag, err
-}
-
-// DeleteAuthorsByFullNameBatch implements Querier.DeleteAuthorsByFullNameBatch.
-func (q *DBQuerier) DeleteAuthorsByFullNameBatch(batch genericBatch, params DeleteAuthorsByFullNameParams) {
-	batch.Queue(deleteAuthorsByFullNameSQL, params.FirstName, params.LastName, params.Suffix)
-}
-
-// DeleteAuthorsByFullNameScan implements Querier.DeleteAuthorsByFullNameScan.
-func (q *DBQuerier) DeleteAuthorsByFullNameScan(results pgx.BatchResults) (pgconn.CommandTag, error) {
-	cmdTag, err := results.Exec()
-	if err != nil {
-		return cmdTag, fmt.Errorf("exec DeleteAuthorsByFullNameBatch: %w", err)
 	}
 	return cmdTag, err
 }

--- a/example/inline_param_count/inline1/query.sql_test.go
+++ b/example/inline_param_count/inline1/query.sql_test.go
@@ -3,7 +3,6 @@ package inline1
 import (
 	"context"
 	"errors"
-	"github.com/jschaf/pggen/internal/errs"
 	"github.com/stretchr/testify/require"
 	"testing"
 
@@ -44,21 +43,6 @@ func TestNewQuerier_FindAuthorByID(t *testing.T) {
 		if !errors.Is(err, pgx.ErrNoRows) {
 			t.Fatalf("expected no rows error to wrap pgx.ErrNoRows; got %s", err)
 		}
-	})
-
-	t.Run("FindAuthorByIDBatch", func(t *testing.T) {
-		batch := &pgx.Batch{}
-		q.FindAuthorByIDBatch(batch, adamsID)
-		results := conn.SendBatch(context.Background(), batch)
-		defer errs.CaptureT(t, results.Close, "close batch results")
-		authors, err := q.FindAuthorByIDScan(results)
-		require.NoError(t, err)
-		assert.Equal(t, FindAuthorByIDRow{
-			AuthorID:  adamsID,
-			FirstName: "john",
-			LastName:  "adams",
-			Suffix:    nil,
-		}, authors)
 	})
 }
 

--- a/example/inline_param_count/inline2/query.sql.go
+++ b/example/inline_param_count/inline2/query.sql.go
@@ -11,42 +11,18 @@ import (
 )
 
 // Querier is a typesafe Go interface backed by SQL queries.
-//
-// Methods ending with Batch enqueue a query to run later in a pgx.Batch. After
-// calling SendBatch on pgx.Conn, pgxpool.Pool, or pgx.Tx, use the Scan methods
-// to parse the results.
 type Querier interface {
 	// CountAuthors returns the number of authors (zero params).
 	CountAuthors(ctx context.Context) (*int, error)
-	// CountAuthorsBatch enqueues a CountAuthors query into batch to be executed
-	// later by the batch.
-	CountAuthorsBatch(batch genericBatch)
-	// CountAuthorsScan scans the result of an executed CountAuthorsBatch query.
-	CountAuthorsScan(results pgx.BatchResults) (*int, error)
 
 	// FindAuthorById finds one (or zero) authors by ID (one param).
 	FindAuthorByID(ctx context.Context, authorID int32) (FindAuthorByIDRow, error)
-	// FindAuthorByIDBatch enqueues a FindAuthorByID query into batch to be executed
-	// later by the batch.
-	FindAuthorByIDBatch(batch genericBatch, authorID int32)
-	// FindAuthorByIDScan scans the result of an executed FindAuthorByIDBatch query.
-	FindAuthorByIDScan(results pgx.BatchResults) (FindAuthorByIDRow, error)
 
 	// InsertAuthor inserts an author by name and returns the ID (two params).
 	InsertAuthor(ctx context.Context, firstName string, lastName string) (int32, error)
-	// InsertAuthorBatch enqueues a InsertAuthor query into batch to be executed
-	// later by the batch.
-	InsertAuthorBatch(batch genericBatch, firstName string, lastName string)
-	// InsertAuthorScan scans the result of an executed InsertAuthorBatch query.
-	InsertAuthorScan(results pgx.BatchResults) (int32, error)
 
 	// DeleteAuthorsByFullName deletes authors by the full name (three params).
 	DeleteAuthorsByFullName(ctx context.Context, params DeleteAuthorsByFullNameParams) (pgconn.CommandTag, error)
-	// DeleteAuthorsByFullNameBatch enqueues a DeleteAuthorsByFullName query into batch to be executed
-	// later by the batch.
-	DeleteAuthorsByFullNameBatch(batch genericBatch, params DeleteAuthorsByFullNameParams)
-	// DeleteAuthorsByFullNameScan scans the result of an executed DeleteAuthorsByFullNameBatch query.
-	DeleteAuthorsByFullNameScan(results pgx.BatchResults) (pgconn.CommandTag, error)
 }
 
 type DBQuerier struct {
@@ -73,14 +49,6 @@ type genericConn interface {
 	// string. arguments should be referenced positionally from the sql string
 	// as $1, $2, etc.
 	Exec(ctx context.Context, sql string, arguments ...interface{}) (pgconn.CommandTag, error)
-}
-
-// genericBatch batches queries to send in a single network request to a
-// Postgres server. This is usually backed by *pgx.Batch.
-type genericBatch interface {
-	// Queue queues a query to batch b. query can be an SQL query or the name of a
-	// prepared statement. See Queue on *pgx.Batch.
-	Queue(query string, arguments ...interface{})
 }
 
 // NewQuerier creates a DBQuerier that implements Querier. conn is typically
@@ -187,21 +155,6 @@ func (q *DBQuerier) CountAuthors(ctx context.Context) (*int, error) {
 	return item, nil
 }
 
-// CountAuthorsBatch implements Querier.CountAuthorsBatch.
-func (q *DBQuerier) CountAuthorsBatch(batch genericBatch) {
-	batch.Queue(countAuthorsSQL)
-}
-
-// CountAuthorsScan implements Querier.CountAuthorsScan.
-func (q *DBQuerier) CountAuthorsScan(results pgx.BatchResults) (*int, error) {
-	row := results.QueryRow()
-	var item *int
-	if err := row.Scan(&item); err != nil {
-		return item, fmt.Errorf("scan CountAuthorsBatch row: %w", err)
-	}
-	return item, nil
-}
-
 const findAuthorByIDSQL = `SELECT * FROM author WHERE author_id = $1;`
 
 type FindAuthorByIDRow struct {
@@ -222,21 +175,6 @@ func (q *DBQuerier) FindAuthorByID(ctx context.Context, authorID int32) (FindAut
 	return item, nil
 }
 
-// FindAuthorByIDBatch implements Querier.FindAuthorByIDBatch.
-func (q *DBQuerier) FindAuthorByIDBatch(batch genericBatch, authorID int32) {
-	batch.Queue(findAuthorByIDSQL, authorID)
-}
-
-// FindAuthorByIDScan implements Querier.FindAuthorByIDScan.
-func (q *DBQuerier) FindAuthorByIDScan(results pgx.BatchResults) (FindAuthorByIDRow, error) {
-	row := results.QueryRow()
-	var item FindAuthorByIDRow
-	if err := row.Scan(&item.AuthorID, &item.FirstName, &item.LastName, &item.Suffix); err != nil {
-		return item, fmt.Errorf("scan FindAuthorByIDBatch row: %w", err)
-	}
-	return item, nil
-}
-
 const insertAuthorSQL = `INSERT INTO author (first_name, last_name)
 VALUES ($1, $2)
 RETURNING author_id;`
@@ -248,21 +186,6 @@ func (q *DBQuerier) InsertAuthor(ctx context.Context, firstName string, lastName
 	var item int32
 	if err := row.Scan(&item); err != nil {
 		return item, fmt.Errorf("query InsertAuthor: %w", err)
-	}
-	return item, nil
-}
-
-// InsertAuthorBatch implements Querier.InsertAuthorBatch.
-func (q *DBQuerier) InsertAuthorBatch(batch genericBatch, firstName string, lastName string) {
-	batch.Queue(insertAuthorSQL, firstName, lastName)
-}
-
-// InsertAuthorScan implements Querier.InsertAuthorScan.
-func (q *DBQuerier) InsertAuthorScan(results pgx.BatchResults) (int32, error) {
-	row := results.QueryRow()
-	var item int32
-	if err := row.Scan(&item); err != nil {
-		return item, fmt.Errorf("scan InsertAuthorBatch row: %w", err)
 	}
 	return item, nil
 }
@@ -285,20 +208,6 @@ func (q *DBQuerier) DeleteAuthorsByFullName(ctx context.Context, params DeleteAu
 	cmdTag, err := q.conn.Exec(ctx, deleteAuthorsByFullNameSQL, params.FirstName, params.LastName, params.Suffix)
 	if err != nil {
 		return cmdTag, fmt.Errorf("exec query DeleteAuthorsByFullName: %w", err)
-	}
-	return cmdTag, err
-}
-
-// DeleteAuthorsByFullNameBatch implements Querier.DeleteAuthorsByFullNameBatch.
-func (q *DBQuerier) DeleteAuthorsByFullNameBatch(batch genericBatch, params DeleteAuthorsByFullNameParams) {
-	batch.Queue(deleteAuthorsByFullNameSQL, params.FirstName, params.LastName, params.Suffix)
-}
-
-// DeleteAuthorsByFullNameScan implements Querier.DeleteAuthorsByFullNameScan.
-func (q *DBQuerier) DeleteAuthorsByFullNameScan(results pgx.BatchResults) (pgconn.CommandTag, error) {
-	cmdTag, err := results.Exec()
-	if err != nil {
-		return cmdTag, fmt.Errorf("exec DeleteAuthorsByFullNameBatch: %w", err)
 	}
 	return cmdTag, err
 }

--- a/example/inline_param_count/inline2/query.sql_test.go
+++ b/example/inline_param_count/inline2/query.sql_test.go
@@ -3,7 +3,6 @@ package inline2
 import (
 	"context"
 	"errors"
-	"github.com/jschaf/pggen/internal/errs"
 	"github.com/stretchr/testify/require"
 	"testing"
 
@@ -44,21 +43,6 @@ func TestNewQuerier_FindAuthorByID(t *testing.T) {
 		if !errors.Is(err, pgx.ErrNoRows) {
 			t.Fatalf("expected no rows error to wrap pgx.ErrNoRows; got %s", err)
 		}
-	})
-
-	t.Run("FindAuthorByIDBatch", func(t *testing.T) {
-		batch := &pgx.Batch{}
-		q.FindAuthorByIDBatch(batch, adamsID)
-		results := conn.SendBatch(context.Background(), batch)
-		defer errs.CaptureT(t, results.Close, "close batch results")
-		authors, err := q.FindAuthorByIDScan(results)
-		require.NoError(t, err)
-		assert.Equal(t, FindAuthorByIDRow{
-			AuthorID:  adamsID,
-			FirstName: "john",
-			LastName:  "adams",
-			Suffix:    nil,
-		}, authors)
 	})
 }
 

--- a/example/inline_param_count/inline3/query.sql.go
+++ b/example/inline_param_count/inline3/query.sql.go
@@ -11,42 +11,18 @@ import (
 )
 
 // Querier is a typesafe Go interface backed by SQL queries.
-//
-// Methods ending with Batch enqueue a query to run later in a pgx.Batch. After
-// calling SendBatch on pgx.Conn, pgxpool.Pool, or pgx.Tx, use the Scan methods
-// to parse the results.
 type Querier interface {
 	// CountAuthors returns the number of authors (zero params).
 	CountAuthors(ctx context.Context) (*int, error)
-	// CountAuthorsBatch enqueues a CountAuthors query into batch to be executed
-	// later by the batch.
-	CountAuthorsBatch(batch genericBatch)
-	// CountAuthorsScan scans the result of an executed CountAuthorsBatch query.
-	CountAuthorsScan(results pgx.BatchResults) (*int, error)
 
 	// FindAuthorById finds one (or zero) authors by ID (one param).
 	FindAuthorByID(ctx context.Context, authorID int32) (FindAuthorByIDRow, error)
-	// FindAuthorByIDBatch enqueues a FindAuthorByID query into batch to be executed
-	// later by the batch.
-	FindAuthorByIDBatch(batch genericBatch, authorID int32)
-	// FindAuthorByIDScan scans the result of an executed FindAuthorByIDBatch query.
-	FindAuthorByIDScan(results pgx.BatchResults) (FindAuthorByIDRow, error)
 
 	// InsertAuthor inserts an author by name and returns the ID (two params).
 	InsertAuthor(ctx context.Context, firstName string, lastName string) (int32, error)
-	// InsertAuthorBatch enqueues a InsertAuthor query into batch to be executed
-	// later by the batch.
-	InsertAuthorBatch(batch genericBatch, firstName string, lastName string)
-	// InsertAuthorScan scans the result of an executed InsertAuthorBatch query.
-	InsertAuthorScan(results pgx.BatchResults) (int32, error)
 
 	// DeleteAuthorsByFullName deletes authors by the full name (three params).
 	DeleteAuthorsByFullName(ctx context.Context, firstName string, lastName string, suffix string) (pgconn.CommandTag, error)
-	// DeleteAuthorsByFullNameBatch enqueues a DeleteAuthorsByFullName query into batch to be executed
-	// later by the batch.
-	DeleteAuthorsByFullNameBatch(batch genericBatch, firstName string, lastName string, suffix string)
-	// DeleteAuthorsByFullNameScan scans the result of an executed DeleteAuthorsByFullNameBatch query.
-	DeleteAuthorsByFullNameScan(results pgx.BatchResults) (pgconn.CommandTag, error)
 }
 
 type DBQuerier struct {
@@ -73,14 +49,6 @@ type genericConn interface {
 	// string. arguments should be referenced positionally from the sql string
 	// as $1, $2, etc.
 	Exec(ctx context.Context, sql string, arguments ...interface{}) (pgconn.CommandTag, error)
-}
-
-// genericBatch batches queries to send in a single network request to a
-// Postgres server. This is usually backed by *pgx.Batch.
-type genericBatch interface {
-	// Queue queues a query to batch b. query can be an SQL query or the name of a
-	// prepared statement. See Queue on *pgx.Batch.
-	Queue(query string, arguments ...interface{})
 }
 
 // NewQuerier creates a DBQuerier that implements Querier. conn is typically
@@ -187,21 +155,6 @@ func (q *DBQuerier) CountAuthors(ctx context.Context) (*int, error) {
 	return item, nil
 }
 
-// CountAuthorsBatch implements Querier.CountAuthorsBatch.
-func (q *DBQuerier) CountAuthorsBatch(batch genericBatch) {
-	batch.Queue(countAuthorsSQL)
-}
-
-// CountAuthorsScan implements Querier.CountAuthorsScan.
-func (q *DBQuerier) CountAuthorsScan(results pgx.BatchResults) (*int, error) {
-	row := results.QueryRow()
-	var item *int
-	if err := row.Scan(&item); err != nil {
-		return item, fmt.Errorf("scan CountAuthorsBatch row: %w", err)
-	}
-	return item, nil
-}
-
 const findAuthorByIDSQL = `SELECT * FROM author WHERE author_id = $1;`
 
 type FindAuthorByIDRow struct {
@@ -222,21 +175,6 @@ func (q *DBQuerier) FindAuthorByID(ctx context.Context, authorID int32) (FindAut
 	return item, nil
 }
 
-// FindAuthorByIDBatch implements Querier.FindAuthorByIDBatch.
-func (q *DBQuerier) FindAuthorByIDBatch(batch genericBatch, authorID int32) {
-	batch.Queue(findAuthorByIDSQL, authorID)
-}
-
-// FindAuthorByIDScan implements Querier.FindAuthorByIDScan.
-func (q *DBQuerier) FindAuthorByIDScan(results pgx.BatchResults) (FindAuthorByIDRow, error) {
-	row := results.QueryRow()
-	var item FindAuthorByIDRow
-	if err := row.Scan(&item.AuthorID, &item.FirstName, &item.LastName, &item.Suffix); err != nil {
-		return item, fmt.Errorf("scan FindAuthorByIDBatch row: %w", err)
-	}
-	return item, nil
-}
-
 const insertAuthorSQL = `INSERT INTO author (first_name, last_name)
 VALUES ($1, $2)
 RETURNING author_id;`
@@ -248,21 +186,6 @@ func (q *DBQuerier) InsertAuthor(ctx context.Context, firstName string, lastName
 	var item int32
 	if err := row.Scan(&item); err != nil {
 		return item, fmt.Errorf("query InsertAuthor: %w", err)
-	}
-	return item, nil
-}
-
-// InsertAuthorBatch implements Querier.InsertAuthorBatch.
-func (q *DBQuerier) InsertAuthorBatch(batch genericBatch, firstName string, lastName string) {
-	batch.Queue(insertAuthorSQL, firstName, lastName)
-}
-
-// InsertAuthorScan implements Querier.InsertAuthorScan.
-func (q *DBQuerier) InsertAuthorScan(results pgx.BatchResults) (int32, error) {
-	row := results.QueryRow()
-	var item int32
-	if err := row.Scan(&item); err != nil {
-		return item, fmt.Errorf("scan InsertAuthorBatch row: %w", err)
 	}
 	return item, nil
 }
@@ -279,20 +202,6 @@ func (q *DBQuerier) DeleteAuthorsByFullName(ctx context.Context, firstName strin
 	cmdTag, err := q.conn.Exec(ctx, deleteAuthorsByFullNameSQL, firstName, lastName, suffix)
 	if err != nil {
 		return cmdTag, fmt.Errorf("exec query DeleteAuthorsByFullName: %w", err)
-	}
-	return cmdTag, err
-}
-
-// DeleteAuthorsByFullNameBatch implements Querier.DeleteAuthorsByFullNameBatch.
-func (q *DBQuerier) DeleteAuthorsByFullNameBatch(batch genericBatch, firstName string, lastName string, suffix string) {
-	batch.Queue(deleteAuthorsByFullNameSQL, firstName, lastName, suffix)
-}
-
-// DeleteAuthorsByFullNameScan implements Querier.DeleteAuthorsByFullNameScan.
-func (q *DBQuerier) DeleteAuthorsByFullNameScan(results pgx.BatchResults) (pgconn.CommandTag, error) {
-	cmdTag, err := results.Exec()
-	if err != nil {
-		return cmdTag, fmt.Errorf("exec DeleteAuthorsByFullNameBatch: %w", err)
 	}
 	return cmdTag, err
 }

--- a/example/inline_param_count/inline3/query.sql_test.go
+++ b/example/inline_param_count/inline3/query.sql_test.go
@@ -3,7 +3,6 @@ package inline3
 import (
 	"context"
 	"errors"
-	"github.com/jschaf/pggen/internal/errs"
 	"github.com/stretchr/testify/require"
 	"testing"
 
@@ -44,21 +43,6 @@ func TestNewQuerier_FindAuthorByID(t *testing.T) {
 		if !errors.Is(err, pgx.ErrNoRows) {
 			t.Fatalf("expected no rows error to wrap pgx.ErrNoRows; got %s", err)
 		}
-	})
-
-	t.Run("FindAuthorByIDBatch", func(t *testing.T) {
-		batch := &pgx.Batch{}
-		q.FindAuthorByIDBatch(batch, adamsID)
-		results := conn.SendBatch(context.Background(), batch)
-		defer errs.CaptureT(t, results.Close, "close batch results")
-		authors, err := q.FindAuthorByIDScan(results)
-		require.NoError(t, err)
-		assert.Equal(t, FindAuthorByIDRow{
-			AuthorID:  adamsID,
-			FirstName: "john",
-			LastName:  "adams",
-			Suffix:    nil,
-		}, authors)
 	})
 }
 

--- a/example/ltree/query.sql.go
+++ b/example/ltree/query.sql.go
@@ -11,38 +11,14 @@ import (
 )
 
 // Querier is a typesafe Go interface backed by SQL queries.
-//
-// Methods ending with Batch enqueue a query to run later in a pgx.Batch. After
-// calling SendBatch on pgx.Conn, pgxpool.Pool, or pgx.Tx, use the Scan methods
-// to parse the results.
 type Querier interface {
 	FindTopScienceChildren(ctx context.Context) ([]pgtype.Text, error)
-	// FindTopScienceChildrenBatch enqueues a FindTopScienceChildren query into batch to be executed
-	// later by the batch.
-	FindTopScienceChildrenBatch(batch genericBatch)
-	// FindTopScienceChildrenScan scans the result of an executed FindTopScienceChildrenBatch query.
-	FindTopScienceChildrenScan(results pgx.BatchResults) ([]pgtype.Text, error)
 
 	FindTopScienceChildrenAgg(ctx context.Context) (pgtype.TextArray, error)
-	// FindTopScienceChildrenAggBatch enqueues a FindTopScienceChildrenAgg query into batch to be executed
-	// later by the batch.
-	FindTopScienceChildrenAggBatch(batch genericBatch)
-	// FindTopScienceChildrenAggScan scans the result of an executed FindTopScienceChildrenAggBatch query.
-	FindTopScienceChildrenAggScan(results pgx.BatchResults) (pgtype.TextArray, error)
 
 	InsertSampleData(ctx context.Context) (pgconn.CommandTag, error)
-	// InsertSampleDataBatch enqueues a InsertSampleData query into batch to be executed
-	// later by the batch.
-	InsertSampleDataBatch(batch genericBatch)
-	// InsertSampleDataScan scans the result of an executed InsertSampleDataBatch query.
-	InsertSampleDataScan(results pgx.BatchResults) (pgconn.CommandTag, error)
 
 	FindLtreeInput(ctx context.Context, inLtree pgtype.Text, inLtreeArray []string) (FindLtreeInputRow, error)
-	// FindLtreeInputBatch enqueues a FindLtreeInput query into batch to be executed
-	// later by the batch.
-	FindLtreeInputBatch(batch genericBatch, inLtree pgtype.Text, inLtreeArray []string)
-	// FindLtreeInputScan scans the result of an executed FindLtreeInputBatch query.
-	FindLtreeInputScan(results pgx.BatchResults) (FindLtreeInputRow, error)
 }
 
 type DBQuerier struct {
@@ -69,14 +45,6 @@ type genericConn interface {
 	// string. arguments should be referenced positionally from the sql string
 	// as $1, $2, etc.
 	Exec(ctx context.Context, sql string, arguments ...interface{}) (pgconn.CommandTag, error)
-}
-
-// genericBatch batches queries to send in a single network request to a
-// Postgres server. This is usually backed by *pgx.Batch.
-type genericBatch interface {
-	// Queue queues a query to batch b. query can be an SQL query or the name of a
-	// prepared statement. See Queue on *pgx.Batch.
-	Queue(query string, arguments ...interface{})
 }
 
 // NewQuerier creates a DBQuerier that implements Querier. conn is typically
@@ -196,32 +164,6 @@ func (q *DBQuerier) FindTopScienceChildren(ctx context.Context) ([]pgtype.Text, 
 	return items, err
 }
 
-// FindTopScienceChildrenBatch implements Querier.FindTopScienceChildrenBatch.
-func (q *DBQuerier) FindTopScienceChildrenBatch(batch genericBatch) {
-	batch.Queue(findTopScienceChildrenSQL)
-}
-
-// FindTopScienceChildrenScan implements Querier.FindTopScienceChildrenScan.
-func (q *DBQuerier) FindTopScienceChildrenScan(results pgx.BatchResults) ([]pgtype.Text, error) {
-	rows, err := results.Query()
-	if err != nil {
-		return nil, fmt.Errorf("query FindTopScienceChildrenBatch: %w", err)
-	}
-	defer rows.Close()
-	items := []pgtype.Text{}
-	for rows.Next() {
-		var item pgtype.Text
-		if err := rows.Scan(&item); err != nil {
-			return nil, fmt.Errorf("scan FindTopScienceChildrenBatch row: %w", err)
-		}
-		items = append(items, item)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("close FindTopScienceChildrenBatch rows: %w", err)
-	}
-	return items, err
-}
-
 const findTopScienceChildrenAggSQL = `SELECT array_agg(path)
 FROM test
 WHERE path <@ 'Top.Science';`
@@ -233,21 +175,6 @@ func (q *DBQuerier) FindTopScienceChildrenAgg(ctx context.Context) (pgtype.TextA
 	var item pgtype.TextArray
 	if err := row.Scan(&item); err != nil {
 		return item, fmt.Errorf("query FindTopScienceChildrenAgg: %w", err)
-	}
-	return item, nil
-}
-
-// FindTopScienceChildrenAggBatch implements Querier.FindTopScienceChildrenAggBatch.
-func (q *DBQuerier) FindTopScienceChildrenAggBatch(batch genericBatch) {
-	batch.Queue(findTopScienceChildrenAggSQL)
-}
-
-// FindTopScienceChildrenAggScan implements Querier.FindTopScienceChildrenAggScan.
-func (q *DBQuerier) FindTopScienceChildrenAggScan(results pgx.BatchResults) (pgtype.TextArray, error) {
-	row := results.QueryRow()
-	var item pgtype.TextArray
-	if err := row.Scan(&item); err != nil {
-		return item, fmt.Errorf("scan FindTopScienceChildrenAggBatch row: %w", err)
 	}
 	return item, nil
 }
@@ -277,20 +204,6 @@ func (q *DBQuerier) InsertSampleData(ctx context.Context) (pgconn.CommandTag, er
 	return cmdTag, err
 }
 
-// InsertSampleDataBatch implements Querier.InsertSampleDataBatch.
-func (q *DBQuerier) InsertSampleDataBatch(batch genericBatch) {
-	batch.Queue(insertSampleDataSQL)
-}
-
-// InsertSampleDataScan implements Querier.InsertSampleDataScan.
-func (q *DBQuerier) InsertSampleDataScan(results pgx.BatchResults) (pgconn.CommandTag, error) {
-	cmdTag, err := results.Exec()
-	if err != nil {
-		return cmdTag, fmt.Errorf("exec InsertSampleDataBatch: %w", err)
-	}
-	return cmdTag, err
-}
-
 const findLtreeInputSQL = `SELECT
   $1::ltree                   AS ltree,
   -- This won't work, but I'm not quite sure why.
@@ -314,21 +227,6 @@ func (q *DBQuerier) FindLtreeInput(ctx context.Context, inLtree pgtype.Text, inL
 	var item FindLtreeInputRow
 	if err := row.Scan(&item.Ltree, &item.TextArr); err != nil {
 		return item, fmt.Errorf("query FindLtreeInput: %w", err)
-	}
-	return item, nil
-}
-
-// FindLtreeInputBatch implements Querier.FindLtreeInputBatch.
-func (q *DBQuerier) FindLtreeInputBatch(batch genericBatch, inLtree pgtype.Text, inLtreeArray []string) {
-	batch.Queue(findLtreeInputSQL, inLtree, inLtreeArray)
-}
-
-// FindLtreeInputScan implements Querier.FindLtreeInputScan.
-func (q *DBQuerier) FindLtreeInputScan(results pgx.BatchResults) (FindLtreeInputRow, error) {
-	row := results.QueryRow()
-	var item FindLtreeInputRow
-	if err := row.Scan(&item.Ltree, &item.TextArr); err != nil {
-		return item, fmt.Errorf("scan FindLtreeInputBatch row: %w", err)
 	}
 	return item, nil
 }

--- a/example/nested/query.sql.go
+++ b/example/nested/query.sql.go
@@ -11,24 +11,10 @@ import (
 )
 
 // Querier is a typesafe Go interface backed by SQL queries.
-//
-// Methods ending with Batch enqueue a query to run later in a pgx.Batch. After
-// calling SendBatch on pgx.Conn, pgxpool.Pool, or pgx.Tx, use the Scan methods
-// to parse the results.
 type Querier interface {
 	ArrayNested2(ctx context.Context) ([]ProductImageType, error)
-	// ArrayNested2Batch enqueues a ArrayNested2 query into batch to be executed
-	// later by the batch.
-	ArrayNested2Batch(batch genericBatch)
-	// ArrayNested2Scan scans the result of an executed ArrayNested2Batch query.
-	ArrayNested2Scan(results pgx.BatchResults) ([]ProductImageType, error)
 
 	Nested3(ctx context.Context) ([]ProductImageSetType, error)
-	// Nested3Batch enqueues a Nested3 query into batch to be executed
-	// later by the batch.
-	Nested3Batch(batch genericBatch)
-	// Nested3Scan scans the result of an executed Nested3Batch query.
-	Nested3Scan(results pgx.BatchResults) ([]ProductImageSetType, error)
 }
 
 type DBQuerier struct {
@@ -55,14 +41,6 @@ type genericConn interface {
 	// string. arguments should be referenced positionally from the sql string
 	// as $1, $2, etc.
 	Exec(ctx context.Context, sql string, arguments ...interface{}) (pgconn.CommandTag, error)
-}
-
-// genericBatch batches queries to send in a single network request to a
-// Postgres server. This is usually backed by *pgx.Batch.
-type genericBatch interface {
-	// Queue queues a query to batch b. query can be an SQL query or the name of a
-	// prepared statement. See Queue on *pgx.Batch.
-	Queue(query string, arguments ...interface{})
 }
 
 // NewQuerier creates a DBQuerier that implements Querier. conn is typically
@@ -278,25 +256,6 @@ func (q *DBQuerier) ArrayNested2(ctx context.Context) ([]ProductImageType, error
 	return item, nil
 }
 
-// ArrayNested2Batch implements Querier.ArrayNested2Batch.
-func (q *DBQuerier) ArrayNested2Batch(batch genericBatch) {
-	batch.Queue(arrayNested2SQL)
-}
-
-// ArrayNested2Scan implements Querier.ArrayNested2Scan.
-func (q *DBQuerier) ArrayNested2Scan(results pgx.BatchResults) ([]ProductImageType, error) {
-	row := results.QueryRow()
-	item := []ProductImageType{}
-	imagesArray := q.types.newProductImageTypeArray()
-	if err := row.Scan(imagesArray); err != nil {
-		return item, fmt.Errorf("scan ArrayNested2Batch row: %w", err)
-	}
-	if err := imagesArray.AssignTo(&item); err != nil {
-		return item, fmt.Errorf("assign ArrayNested2 row: %w", err)
-	}
-	return item, nil
-}
-
 const nested3SQL = `SELECT
   ROW (
     'name', -- name
@@ -329,36 +288,6 @@ func (q *DBQuerier) Nested3(ctx context.Context) ([]ProductImageSetType, error) 
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("close Nested3 rows: %w", err)
-	}
-	return items, err
-}
-
-// Nested3Batch implements Querier.Nested3Batch.
-func (q *DBQuerier) Nested3Batch(batch genericBatch) {
-	batch.Queue(nested3SQL)
-}
-
-// Nested3Scan implements Querier.Nested3Scan.
-func (q *DBQuerier) Nested3Scan(results pgx.BatchResults) ([]ProductImageSetType, error) {
-	rows, err := results.Query()
-	if err != nil {
-		return nil, fmt.Errorf("query Nested3Batch: %w", err)
-	}
-	defer rows.Close()
-	items := []ProductImageSetType{}
-	rowRow := q.types.newProductImageSetType()
-	for rows.Next() {
-		var item ProductImageSetType
-		if err := rows.Scan(rowRow); err != nil {
-			return nil, fmt.Errorf("scan Nested3Batch row: %w", err)
-		}
-		if err := rowRow.AssignTo(&item); err != nil {
-			return nil, fmt.Errorf("assign Nested3 row: %w", err)
-		}
-		items = append(items, item)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("close Nested3Batch rows: %w", err)
 	}
 	return items, err
 }

--- a/example/nested/query.sql_test.go
+++ b/example/nested/query.sql_test.go
@@ -2,7 +2,6 @@ package nested
 
 import (
 	"context"
-	"github.com/jackc/pgx/v4"
 	"github.com/jschaf/pggen/internal/pgtest"
 	"github.com/stretchr/testify/assert"
 	"testing"
@@ -21,17 +20,6 @@ func TestNewQuerier_ArrayNested2(t *testing.T) {
 	}
 	t.Run("ArrayNested2", func(t *testing.T) {
 		rows, err := q.ArrayNested2(ctx)
-		if err != nil {
-			t.Fatal(err)
-		}
-		assert.Equal(t, want, rows)
-	})
-
-	t.Run("ArrayNested2Batch", func(t *testing.T) {
-		batch := &pgx.Batch{}
-		q.ArrayNested2Batch(batch)
-		results := conn.SendBatch(ctx, batch)
-		rows, err := q.ArrayNested2Scan(results)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -62,18 +50,6 @@ func TestNewQuerier_Nested3(t *testing.T) {
 	t.Run("Nested3", func(t *testing.T) {
 		t.Skipf("https://github.com/jackc/pgx/issues/874")
 		rows, err := q.Nested3(ctx)
-		if err != nil {
-			t.Fatal(err)
-		}
-		assert.Equal(t, want, rows)
-	})
-
-	t.Run("Nested3Batch", func(t *testing.T) {
-		t.Skipf("https://github.com/jackc/pgx/issues/874")
-		batch := &pgx.Batch{}
-		q.Nested3Batch(batch)
-		results := conn.SendBatch(ctx, batch)
-		rows, err := q.Nested3Scan(results)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/example/separate_out_dir/out/alpha_query.sql.1.go
+++ b/example/separate_out_dir/out/alpha_query.sql.1.go
@@ -5,7 +5,6 @@ package out
 import (
 	"context"
 	"fmt"
-	"github.com/jackc/pgx/v4"
 )
 
 const alphaSQL = `SELECT 'alpha' as output;`
@@ -17,21 +16,6 @@ func (q *DBQuerier) Alpha(ctx context.Context) (string, error) {
 	var item string
 	if err := row.Scan(&item); err != nil {
 		return item, fmt.Errorf("query Alpha: %w", err)
-	}
-	return item, nil
-}
-
-// AlphaBatch implements Querier.AlphaBatch.
-func (q *DBQuerier) AlphaBatch(batch genericBatch) {
-	batch.Queue(alphaSQL)
-}
-
-// AlphaScan implements Querier.AlphaScan.
-func (q *DBQuerier) AlphaScan(results pgx.BatchResults) (string, error) {
-	row := results.QueryRow()
-	var item string
-	if err := row.Scan(&item); err != nil {
-		return item, fmt.Errorf("scan AlphaBatch row: %w", err)
 	}
 	return item, nil
 }

--- a/example/separate_out_dir/out/bravo_query.sql.go
+++ b/example/separate_out_dir/out/bravo_query.sql.go
@@ -5,7 +5,6 @@ package out
 import (
 	"context"
 	"fmt"
-	"github.com/jackc/pgx/v4"
 )
 
 const bravoSQL = `SELECT 'bravo' as output;`
@@ -17,21 +16,6 @@ func (q *DBQuerier) Bravo(ctx context.Context) (string, error) {
 	var item string
 	if err := row.Scan(&item); err != nil {
 		return item, fmt.Errorf("query Bravo: %w", err)
-	}
-	return item, nil
-}
-
-// BravoBatch implements Querier.BravoBatch.
-func (q *DBQuerier) BravoBatch(batch genericBatch) {
-	batch.Queue(bravoSQL)
-}
-
-// BravoScan implements Querier.BravoScan.
-func (q *DBQuerier) BravoScan(results pgx.BatchResults) (string, error) {
-	row := results.QueryRow()
-	var item string
-	if err := row.Scan(&item); err != nil {
-		return item, fmt.Errorf("scan BravoBatch row: %w", err)
 	}
 	return item, nil
 }

--- a/example/slices/query.sql_test.go
+++ b/example/slices/query.sql_test.go
@@ -2,9 +2,7 @@ package slices
 
 import (
 	"context"
-	"github.com/jackc/pgx/v4"
 	"github.com/jschaf/pggen/internal/difftest"
-	"github.com/jschaf/pggen/internal/errs"
 	"github.com/jschaf/pggen/internal/pgtest"
 	"github.com/stretchr/testify/require"
 	"testing"
@@ -24,17 +22,6 @@ func TestNewQuerier_GetBools(t *testing.T) {
 		require.NoError(t, err)
 		difftest.AssertSame(t, want, got)
 	})
-
-	t.Run("GetBoolsBatch", func(t *testing.T) {
-		batch := &pgx.Batch{}
-		want := []bool{true, true, false}
-		q.GetBoolsBatch(batch, want)
-		results := conn.SendBatch(ctx, batch)
-		defer errs.CaptureT(t, results.Close, "close batch results")
-		got, err := q.GetBoolsScan(results)
-		require.NoError(t, err)
-		difftest.AssertSame(t, want, got)
-	})
 }
 
 func TestNewQuerier_GetOneTimestamp(t *testing.T) {
@@ -47,16 +34,6 @@ func TestNewQuerier_GetOneTimestamp(t *testing.T) {
 
 	t.Run("GetOneTimestamp", func(t *testing.T) {
 		got, err := q.GetOneTimestamp(ctx, &ts)
-		require.NoError(t, err)
-		difftest.AssertSame(t, &ts, got)
-	})
-
-	t.Run("GetOneTimestampBatch", func(t *testing.T) {
-		batch := &pgx.Batch{}
-		q.GetOneTimestampBatch(batch, &ts)
-		results := conn.SendBatch(ctx, batch)
-		defer errs.CaptureT(t, results.Close, "close batch results")
-		got, err := q.GetOneTimestampScan(results)
 		require.NoError(t, err)
 		difftest.AssertSame(t, &ts, got)
 	})
@@ -73,16 +50,6 @@ func TestNewQuerier_GetManyTimestamptzs(t *testing.T) {
 
 	t.Run("GetManyTimestamptzs", func(t *testing.T) {
 		got, err := q.GetManyTimestamptzs(ctx, []time.Time{ts1, ts2})
-		require.NoError(t, err)
-		difftest.AssertSame(t, []*time.Time{&ts1, &ts2}, got)
-	})
-
-	t.Run("GetManyTimestamptzsBatch", func(t *testing.T) {
-		batch := &pgx.Batch{}
-		q.GetManyTimestamptzsBatch(batch, []time.Time{ts1, ts2})
-		results := conn.SendBatch(ctx, batch)
-		defer errs.CaptureT(t, results.Close, "close batch results")
-		got, err := q.GetManyTimestamptzsScan(results)
 		require.NoError(t, err)
 		difftest.AssertSame(t, []*time.Time{&ts1, &ts2}, got)
 	})

--- a/example/syntax/query.sql_test.go
+++ b/example/syntax/query.sql_test.go
@@ -2,7 +2,6 @@ package syntax
 
 import (
 	"context"
-	"github.com/jackc/pgx/v4"
 	"github.com/jschaf/pggen/internal/pgtest"
 	"github.com/stretchr/testify/assert"
 	"testing"
@@ -33,32 +32,4 @@ func TestQuerier(t *testing.T) {
 	val, err = q.BacktickBackslashN(ctx)
 	assert.NoError(t, err, "BacktickBackslashN")
 	assert.Equal(t, "`\\n", val, "BacktickBackslashN")
-
-	batch := &pgx.Batch{}
-	q.BacktickBatch(batch)
-	q.BacktickDoubleQuoteBatch(batch)
-	q.BacktickQuoteBacktickBatch(batch)
-	q.BacktickNewlineBatch(batch)
-	q.BacktickBackslashNBatch(batch)
-	results := conn.SendBatch(ctx, batch)
-
-	val, err = q.BacktickScan(results)
-	assert.NoError(t, err, "BacktickScan")
-	assert.Equal(t, "`", val, "BacktickScan")
-
-	val, err = q.BacktickDoubleQuoteScan(results)
-	assert.NoError(t, err, "BacktickDoubleQuoteScan")
-	assert.Equal(t, "`\"", val, "BacktickDoubleQuoteScan")
-
-	val, err = q.BacktickQuoteBacktickScan(results)
-	assert.NoError(t, err, "BacktickQuoteBacktickScan")
-	assert.Equal(t, "`\"`", val, "BacktickQuoteBacktickScan")
-
-	val, err = q.BacktickNewlineScan(results)
-	assert.NoError(t, err, "BacktickNewlineScan")
-	assert.Equal(t, "`\n", val, "BacktickNewlineScan")
-
-	val, err = q.BacktickBackslashNScan(results)
-	assert.NoError(t, err, "BacktickBackslashNScan")
-	assert.Equal(t, "`\\n", val, "BacktickBackslashNScan")
 }

--- a/example/void/query.sql.go
+++ b/example/void/query.sql.go
@@ -11,45 +11,16 @@ import (
 )
 
 // Querier is a typesafe Go interface backed by SQL queries.
-//
-// Methods ending with Batch enqueue a query to run later in a pgx.Batch. After
-// calling SendBatch on pgx.Conn, pgxpool.Pool, or pgx.Tx, use the Scan methods
-// to parse the results.
 type Querier interface {
 	VoidOnly(ctx context.Context) (pgconn.CommandTag, error)
-	// VoidOnlyBatch enqueues a VoidOnly query into batch to be executed
-	// later by the batch.
-	VoidOnlyBatch(batch genericBatch)
-	// VoidOnlyScan scans the result of an executed VoidOnlyBatch query.
-	VoidOnlyScan(results pgx.BatchResults) (pgconn.CommandTag, error)
 
 	VoidOnlyTwoParams(ctx context.Context, id int32) (pgconn.CommandTag, error)
-	// VoidOnlyTwoParamsBatch enqueues a VoidOnlyTwoParams query into batch to be executed
-	// later by the batch.
-	VoidOnlyTwoParamsBatch(batch genericBatch, id int32)
-	// VoidOnlyTwoParamsScan scans the result of an executed VoidOnlyTwoParamsBatch query.
-	VoidOnlyTwoParamsScan(results pgx.BatchResults) (pgconn.CommandTag, error)
 
 	VoidTwo(ctx context.Context) (string, error)
-	// VoidTwoBatch enqueues a VoidTwo query into batch to be executed
-	// later by the batch.
-	VoidTwoBatch(batch genericBatch)
-	// VoidTwoScan scans the result of an executed VoidTwoBatch query.
-	VoidTwoScan(results pgx.BatchResults) (string, error)
 
 	VoidThree(ctx context.Context) (VoidThreeRow, error)
-	// VoidThreeBatch enqueues a VoidThree query into batch to be executed
-	// later by the batch.
-	VoidThreeBatch(batch genericBatch)
-	// VoidThreeScan scans the result of an executed VoidThreeBatch query.
-	VoidThreeScan(results pgx.BatchResults) (VoidThreeRow, error)
 
 	VoidThree2(ctx context.Context) ([]string, error)
-	// VoidThree2Batch enqueues a VoidThree2 query into batch to be executed
-	// later by the batch.
-	VoidThree2Batch(batch genericBatch)
-	// VoidThree2Scan scans the result of an executed VoidThree2Batch query.
-	VoidThree2Scan(results pgx.BatchResults) ([]string, error)
 }
 
 type DBQuerier struct {
@@ -76,14 +47,6 @@ type genericConn interface {
 	// string. arguments should be referenced positionally from the sql string
 	// as $1, $2, etc.
 	Exec(ctx context.Context, sql string, arguments ...interface{}) (pgconn.CommandTag, error)
-}
-
-// genericBatch batches queries to send in a single network request to a
-// Postgres server. This is usually backed by *pgx.Batch.
-type genericBatch interface {
-	// Queue queues a query to batch b. query can be an SQL query or the name of a
-	// prepared statement. See Queue on *pgx.Batch.
-	Queue(query string, arguments ...interface{})
 }
 
 // NewQuerier creates a DBQuerier that implements Querier. conn is typically
@@ -192,20 +155,6 @@ func (q *DBQuerier) VoidOnly(ctx context.Context) (pgconn.CommandTag, error) {
 	return cmdTag, err
 }
 
-// VoidOnlyBatch implements Querier.VoidOnlyBatch.
-func (q *DBQuerier) VoidOnlyBatch(batch genericBatch) {
-	batch.Queue(voidOnlySQL)
-}
-
-// VoidOnlyScan implements Querier.VoidOnlyScan.
-func (q *DBQuerier) VoidOnlyScan(results pgx.BatchResults) (pgconn.CommandTag, error) {
-	cmdTag, err := results.Exec()
-	if err != nil {
-		return cmdTag, fmt.Errorf("exec VoidOnlyBatch: %w", err)
-	}
-	return cmdTag, err
-}
-
 const voidOnlyTwoParamsSQL = `SELECT void_fn_two_params($1, 'text');`
 
 // VoidOnlyTwoParams implements Querier.VoidOnlyTwoParams.
@@ -214,20 +163,6 @@ func (q *DBQuerier) VoidOnlyTwoParams(ctx context.Context, id int32) (pgconn.Com
 	cmdTag, err := q.conn.Exec(ctx, voidOnlyTwoParamsSQL, id)
 	if err != nil {
 		return cmdTag, fmt.Errorf("exec query VoidOnlyTwoParams: %w", err)
-	}
-	return cmdTag, err
-}
-
-// VoidOnlyTwoParamsBatch implements Querier.VoidOnlyTwoParamsBatch.
-func (q *DBQuerier) VoidOnlyTwoParamsBatch(batch genericBatch, id int32) {
-	batch.Queue(voidOnlyTwoParamsSQL, id)
-}
-
-// VoidOnlyTwoParamsScan implements Querier.VoidOnlyTwoParamsScan.
-func (q *DBQuerier) VoidOnlyTwoParamsScan(results pgx.BatchResults) (pgconn.CommandTag, error) {
-	cmdTag, err := results.Exec()
-	if err != nil {
-		return cmdTag, fmt.Errorf("exec VoidOnlyTwoParamsBatch: %w", err)
 	}
 	return cmdTag, err
 }
@@ -241,21 +176,6 @@ func (q *DBQuerier) VoidTwo(ctx context.Context) (string, error) {
 	var item string
 	if err := row.Scan(nil, &item); err != nil {
 		return item, fmt.Errorf("query VoidTwo: %w", err)
-	}
-	return item, nil
-}
-
-// VoidTwoBatch implements Querier.VoidTwoBatch.
-func (q *DBQuerier) VoidTwoBatch(batch genericBatch) {
-	batch.Queue(voidTwoSQL)
-}
-
-// VoidTwoScan implements Querier.VoidTwoScan.
-func (q *DBQuerier) VoidTwoScan(results pgx.BatchResults) (string, error) {
-	row := results.QueryRow()
-	var item string
-	if err := row.Scan(nil, &item); err != nil {
-		return item, fmt.Errorf("scan VoidTwoBatch row: %w", err)
 	}
 	return item, nil
 }
@@ -274,21 +194,6 @@ func (q *DBQuerier) VoidThree(ctx context.Context) (VoidThreeRow, error) {
 	var item VoidThreeRow
 	if err := row.Scan(nil, &item.Foo, &item.Bar); err != nil {
 		return item, fmt.Errorf("query VoidThree: %w", err)
-	}
-	return item, nil
-}
-
-// VoidThreeBatch implements Querier.VoidThreeBatch.
-func (q *DBQuerier) VoidThreeBatch(batch genericBatch) {
-	batch.Queue(voidThreeSQL)
-}
-
-// VoidThreeScan implements Querier.VoidThreeScan.
-func (q *DBQuerier) VoidThreeScan(results pgx.BatchResults) (VoidThreeRow, error) {
-	row := results.QueryRow()
-	var item VoidThreeRow
-	if err := row.Scan(nil, &item.Foo, &item.Bar); err != nil {
-		return item, fmt.Errorf("scan VoidThreeBatch row: %w", err)
 	}
 	return item, nil
 }
@@ -313,32 +218,6 @@ func (q *DBQuerier) VoidThree2(ctx context.Context) ([]string, error) {
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("close VoidThree2 rows: %w", err)
-	}
-	return items, err
-}
-
-// VoidThree2Batch implements Querier.VoidThree2Batch.
-func (q *DBQuerier) VoidThree2Batch(batch genericBatch) {
-	batch.Queue(voidThree2SQL)
-}
-
-// VoidThree2Scan implements Querier.VoidThree2Scan.
-func (q *DBQuerier) VoidThree2Scan(results pgx.BatchResults) ([]string, error) {
-	rows, err := results.Query()
-	if err != nil {
-		return nil, fmt.Errorf("query VoidThree2Batch: %w", err)
-	}
-	defer rows.Close()
-	items := []string{}
-	for rows.Next() {
-		var item string
-		if err := rows.Scan(&item, nil, nil); err != nil {
-			return nil, fmt.Errorf("scan VoidThree2Batch row: %w", err)
-		}
-		items = append(items, item)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("close VoidThree2Batch rows: %w", err)
 	}
 	return items, err
 }

--- a/internal/codegen/golang/query.gotemplate
+++ b/internal/codegen/golang/query.gotemplate
@@ -14,20 +14,11 @@ import (
 {{- if .IsLeader -}}
 {{- "\n\n" -}}
 // Querier is a typesafe Go interface backed by SQL queries.
-//
-// Methods ending with Batch enqueue a query to run later in a pgx.Batch. After
-// calling SendBatch on pgx.Conn, pgxpool.Pool, or pgx.Tx, use the Scan methods
-// to parse the results.
 type Querier interface {
 {{- range $pkgFile := .Pkg.Files -}}
 {{- range $i, $q := $pkgFile.Queries }} {{- "\n\t" -}}
 	{{- if $q.Doc }}{{ $q.Doc }}	{{ end -}}
 	{{.Name}}(ctx context.Context {{- $q.EmitParams }}) ({{ $q.EmitResultType }}, error)
-	// {{.Name}}Batch enqueues a {{.Name}} query into batch to be executed
-	// later by the batch.
-	{{.Name}}Batch(batch genericBatch {{- $q.EmitParams }})
-	// {{.Name}}Scan scans the result of an executed {{.Name}}Batch query.
-	{{.Name}}Scan(results pgx.BatchResults) ({{ $q.EmitResultType }}, error)
 	{{- "\n" -}}
 {{end -}}
 {{- end -}}
@@ -57,14 +48,6 @@ type genericConn interface {
 	// string. arguments should be referenced positionally from the sql string
 	// as $1, $2, etc.
 	Exec(ctx context.Context, sql string, arguments ...interface{}) (pgconn.CommandTag, error)
-}
-
-// genericBatch batches queries to send in a single network request to a
-// Postgres server. This is usually backed by *pgx.Batch.
-type genericBatch interface {
-	// Queue queues a query to batch b. query can be an SQL query or the name of a
-	// prepared statement. See Queue on *pgx.Batch.
-	Queue(query string, arguments ...interface{})
 }
 
 // NewQuerier creates a DBQuerier that implements Querier. conn is typically
@@ -162,51 +145,6 @@ func (q *DBQuerier) {{ $q.Name }}(ctx context.Context {{- $q.EmitParams }}) ({{ 
 	cmdTag, err := q.conn.Exec(ctx, {{ $q.SQLVarName }} {{- $q.EmitParamNames }})
 	if err != nil {
 		return cmdTag, fmt.Errorf("exec query {{ $q.Name }}: %w", err)
-	}
-	return cmdTag, err
-{{- end }}
-}
-
-// {{$q.Name}}Batch implements Querier.{{$q.Name}}Batch.
-func (q *DBQuerier) {{.Name}}Batch(batch genericBatch {{- $q.EmitParams }}) {
-	batch.Queue({{ $q.SQLVarName }} {{- $q.EmitParamNames }})
-}
-
-// {{.Name}}Scan implements Querier.{{$q.Name}}Scan.
-func (q *DBQuerier) {{.Name}}Scan(results pgx.BatchResults) ({{ $q.EmitResultType }}, error) {
-{{- if eq $q.ResultKind ":one" }}
-	row := results.QueryRow()
-	{{ $q.EmitResultTypeInit "item" }}
-	{{- $q.EmitResultDecoders }}
-	if err := row.Scan({{ $q.EmitRowScanArgs }}); err != nil {
-		return {{ $q.EmitResultExpr "item" }}, fmt.Errorf("scan {{ $q.Name }}Batch row: %w", err)
-	}
-	{{- $q.EmitResultAssigns "item" }}
-	return {{ $q.EmitResultExpr "item" }}, nil
-{{- else if eq $q.ResultKind ":many" }}
-	rows, err := results.Query()
-	if err != nil {
-		return nil, fmt.Errorf("query {{ $q.Name }}Batch: %w", err)
-	}
-	defer rows.Close()
-	{{ $q.EmitResultTypeInit "items" }}
-	{{- $q.EmitResultDecoders }}
-	for rows.Next() {
-		var item {{ $q.EmitResultElem }}
-		if err := rows.Scan({{- $q.EmitRowScanArgs -}}); err != nil {
-			return nil, fmt.Errorf("scan {{ $q.Name }}Batch row: %w", err)
-		}
-		{{- $q.EmitResultAssigns "nil" }}
-		items = append(items, {{ $q.EmitResultExpr "item" }})
-	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("close {{ $q.Name }}Batch rows: %w", err)
-	}
-	return items, err
-{{- else if eq $q.ResultKind ":exec" }}
-	cmdTag, err := results.Exec()
-	if err != nil {
-		return cmdTag, fmt.Errorf("exec {{ $q.Name }}Batch: %w", err)
 	}
 	return cmdTag, err
 {{- end }}

--- a/internal/codegen/golang/templated_file.go
+++ b/internal/codegen/golang/templated_file.go
@@ -103,8 +103,8 @@ func (tq TemplatedQuery) EmitParams() string {
 func getLongestInput(inputs []TemplatedParam) (int, int) {
 	nameLen := 0
 	for _, out := range inputs {
-		if len(out.RawName.PgName) > nameLen {
-			nameLen = len(out.RawName.PgName)
+		if len(out.UpperName) > nameLen {
+			nameLen = len(out.UpperName)
 		}
 	}
 	nameLen++ // 1 space to separate name from type

--- a/internal/codegen/golang/templater.go
+++ b/internal/codegen/golang/templater.go
@@ -116,8 +116,8 @@ func (tm Templater) templateFile(file codegen.QueryFile, isLeader bool) (Templat
 	imports.AddPackage("github.com/jackc/pgconn")
 	if isLeader {
 		imports.AddPackage("github.com/jackc/pgtype")
+		imports.AddPackage("github.com/jackc/pgx/v4")
 	}
-	imports.AddPackage("github.com/jackc/pgx/v4")
 
 	pkgPath := ""
 	// NOTE: err == nil check


### PR DESCRIPTION
PGXv5 dramatically changes how batch queries work. In v4 we use a separate batch and scan call. In v5, we use a callback with generics for type safety.

Remove batch queries for now since it complicates upgrading to pgx V5. We may them back in later with a more ergonomic API.

#74