### PR TITLE
Shorten docs for generic conn

### DIFF
--- a/example/author/query.sql.go
+++ b/example/author/query.sql.go
@@ -45,41 +45,23 @@ type Querier interface {
 	ArrayAggFirstName(ctx context.Context, authorID int32) ([]string, error)
 }
 
+var _ Querier = &DBQuerier{}
+
 type DBQuerier struct {
 	conn  genericConn   // underlying Postgres transport to use
 	types *typeResolver // resolve types by name
 }
 
-var _ Querier = &DBQuerier{}
-
-// genericConn is a connection to a Postgres database. This is usually backed by
-// *pgx.Conn, pgx.Tx, or *pgxpool.Pool.
+// genericConn is a connection like *pgx.Conn, pgx.Tx, or *pgxpool.Pool.
 type genericConn interface {
-	// Query executes sql with args. If there is an error the returned Rows will
-	// be returned in an error state. So it is allowed to ignore the error
-	// returned from Query and handle it in Rows.
-	Query(ctx context.Context, sql string, args ...interface{}) (pgx.Rows, error)
-
-	// QueryRow is a convenience wrapper over Query. Any error that occurs while
-	// querying is deferred until calling Scan on the returned Row. That Row will
-	// error with pgx.ErrNoRows if no rows are returned.
-	QueryRow(ctx context.Context, sql string, args ...interface{}) pgx.Row
-
-	// Exec executes sql. sql can be either a prepared statement name or an SQL
-	// string. arguments should be referenced positionally from the sql string
-	// as $1, $2, etc.
-	Exec(ctx context.Context, sql string, arguments ...interface{}) (pgconn.CommandTag, error)
+	Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error)
+	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
+	Exec(ctx context.Context, sql string, arguments ...any) (pgconn.CommandTag, error)
 }
 
-// NewQuerier creates a DBQuerier that implements Querier. conn is typically
-// *pgx.Conn, pgx.Tx, or *pgxpool.Pool.
+// NewQuerier creates a DBQuerier that implements Querier.
 func NewQuerier(conn genericConn) *DBQuerier {
 	return &DBQuerier{conn: conn, types: newTypeResolver()}
-}
-
-// WithTx creates a new DBQuerier that uses the transaction to run all queries.
-func (q *DBQuerier) WithTx(tx pgx.Tx) (*DBQuerier, error) {
-	return &DBQuerier{conn: tx}, nil
 }
 
 // typeResolver looks up the pgtype.ValueTranscoder by Postgres type name.

--- a/example/composite/query.sql.go
+++ b/example/composite/query.sql.go
@@ -23,41 +23,23 @@ type Querier interface {
 	UserEmails(ctx context.Context) (UserEmail, error)
 }
 
+var _ Querier = &DBQuerier{}
+
 type DBQuerier struct {
 	conn  genericConn   // underlying Postgres transport to use
 	types *typeResolver // resolve types by name
 }
 
-var _ Querier = &DBQuerier{}
-
-// genericConn is a connection to a Postgres database. This is usually backed by
-// *pgx.Conn, pgx.Tx, or *pgxpool.Pool.
+// genericConn is a connection like *pgx.Conn, pgx.Tx, or *pgxpool.Pool.
 type genericConn interface {
-	// Query executes sql with args. If there is an error the returned Rows will
-	// be returned in an error state. So it is allowed to ignore the error
-	// returned from Query and handle it in Rows.
-	Query(ctx context.Context, sql string, args ...interface{}) (pgx.Rows, error)
-
-	// QueryRow is a convenience wrapper over Query. Any error that occurs while
-	// querying is deferred until calling Scan on the returned Row. That Row will
-	// error with pgx.ErrNoRows if no rows are returned.
-	QueryRow(ctx context.Context, sql string, args ...interface{}) pgx.Row
-
-	// Exec executes sql. sql can be either a prepared statement name or an SQL
-	// string. arguments should be referenced positionally from the sql string
-	// as $1, $2, etc.
-	Exec(ctx context.Context, sql string, arguments ...interface{}) (pgconn.CommandTag, error)
+	Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error)
+	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
+	Exec(ctx context.Context, sql string, arguments ...any) (pgconn.CommandTag, error)
 }
 
-// NewQuerier creates a DBQuerier that implements Querier. conn is typically
-// *pgx.Conn, pgx.Tx, or *pgxpool.Pool.
+// NewQuerier creates a DBQuerier that implements Querier.
 func NewQuerier(conn genericConn) *DBQuerier {
 	return &DBQuerier{conn: conn, types: newTypeResolver()}
-}
-
-// WithTx creates a new DBQuerier that uses the transaction to run all queries.
-func (q *DBQuerier) WithTx(tx pgx.Tx) (*DBQuerier, error) {
-	return &DBQuerier{conn: tx}, nil
 }
 
 // Arrays represents the Postgres composite type "arrays".

--- a/example/custom_types/query.sql.go
+++ b/example/custom_types/query.sql.go
@@ -20,41 +20,23 @@ type Querier interface {
 	IntArray(ctx context.Context) ([][]int32, error)
 }
 
+var _ Querier = &DBQuerier{}
+
 type DBQuerier struct {
 	conn  genericConn   // underlying Postgres transport to use
 	types *typeResolver // resolve types by name
 }
 
-var _ Querier = &DBQuerier{}
-
-// genericConn is a connection to a Postgres database. This is usually backed by
-// *pgx.Conn, pgx.Tx, or *pgxpool.Pool.
+// genericConn is a connection like *pgx.Conn, pgx.Tx, or *pgxpool.Pool.
 type genericConn interface {
-	// Query executes sql with args. If there is an error the returned Rows will
-	// be returned in an error state. So it is allowed to ignore the error
-	// returned from Query and handle it in Rows.
-	Query(ctx context.Context, sql string, args ...interface{}) (pgx.Rows, error)
-
-	// QueryRow is a convenience wrapper over Query. Any error that occurs while
-	// querying is deferred until calling Scan on the returned Row. That Row will
-	// error with pgx.ErrNoRows if no rows are returned.
-	QueryRow(ctx context.Context, sql string, args ...interface{}) pgx.Row
-
-	// Exec executes sql. sql can be either a prepared statement name or an SQL
-	// string. arguments should be referenced positionally from the sql string
-	// as $1, $2, etc.
-	Exec(ctx context.Context, sql string, arguments ...interface{}) (pgconn.CommandTag, error)
+	Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error)
+	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
+	Exec(ctx context.Context, sql string, arguments ...any) (pgconn.CommandTag, error)
 }
 
-// NewQuerier creates a DBQuerier that implements Querier. conn is typically
-// *pgx.Conn, pgx.Tx, or *pgxpool.Pool.
+// NewQuerier creates a DBQuerier that implements Querier.
 func NewQuerier(conn genericConn) *DBQuerier {
 	return &DBQuerier{conn: conn, types: newTypeResolver()}
-}
-
-// WithTx creates a new DBQuerier that uses the transaction to run all queries.
-func (q *DBQuerier) WithTx(tx pgx.Tx) (*DBQuerier, error) {
-	return &DBQuerier{conn: tx}, nil
 }
 
 // typeResolver looks up the pgtype.ValueTranscoder by Postgres type name.

--- a/example/device/query.sql.go
+++ b/example/device/query.sql.go
@@ -27,41 +27,23 @@ type Querier interface {
 	InsertDevice(ctx context.Context, mac pgtype.Macaddr, owner int) (pgconn.CommandTag, error)
 }
 
+var _ Querier = &DBQuerier{}
+
 type DBQuerier struct {
 	conn  genericConn   // underlying Postgres transport to use
 	types *typeResolver // resolve types by name
 }
 
-var _ Querier = &DBQuerier{}
-
-// genericConn is a connection to a Postgres database. This is usually backed by
-// *pgx.Conn, pgx.Tx, or *pgxpool.Pool.
+// genericConn is a connection like *pgx.Conn, pgx.Tx, or *pgxpool.Pool.
 type genericConn interface {
-	// Query executes sql with args. If there is an error the returned Rows will
-	// be returned in an error state. So it is allowed to ignore the error
-	// returned from Query and handle it in Rows.
-	Query(ctx context.Context, sql string, args ...interface{}) (pgx.Rows, error)
-
-	// QueryRow is a convenience wrapper over Query. Any error that occurs while
-	// querying is deferred until calling Scan on the returned Row. That Row will
-	// error with pgx.ErrNoRows if no rows are returned.
-	QueryRow(ctx context.Context, sql string, args ...interface{}) pgx.Row
-
-	// Exec executes sql. sql can be either a prepared statement name or an SQL
-	// string. arguments should be referenced positionally from the sql string
-	// as $1, $2, etc.
-	Exec(ctx context.Context, sql string, arguments ...interface{}) (pgconn.CommandTag, error)
+	Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error)
+	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
+	Exec(ctx context.Context, sql string, arguments ...any) (pgconn.CommandTag, error)
 }
 
-// NewQuerier creates a DBQuerier that implements Querier. conn is typically
-// *pgx.Conn, pgx.Tx, or *pgxpool.Pool.
+// NewQuerier creates a DBQuerier that implements Querier.
 func NewQuerier(conn genericConn) *DBQuerier {
 	return &DBQuerier{conn: conn, types: newTypeResolver()}
-}
-
-// WithTx creates a new DBQuerier that uses the transaction to run all queries.
-func (q *DBQuerier) WithTx(tx pgx.Tx) (*DBQuerier, error) {
-	return &DBQuerier{conn: tx}, nil
 }
 
 // User represents the Postgres composite type "user".

--- a/example/domain/query.sql.go
+++ b/example/domain/query.sql.go
@@ -15,41 +15,23 @@ type Querier interface {
 	DomainOne(ctx context.Context) (string, error)
 }
 
+var _ Querier = &DBQuerier{}
+
 type DBQuerier struct {
 	conn  genericConn   // underlying Postgres transport to use
 	types *typeResolver // resolve types by name
 }
 
-var _ Querier = &DBQuerier{}
-
-// genericConn is a connection to a Postgres database. This is usually backed by
-// *pgx.Conn, pgx.Tx, or *pgxpool.Pool.
+// genericConn is a connection like *pgx.Conn, pgx.Tx, or *pgxpool.Pool.
 type genericConn interface {
-	// Query executes sql with args. If there is an error the returned Rows will
-	// be returned in an error state. So it is allowed to ignore the error
-	// returned from Query and handle it in Rows.
-	Query(ctx context.Context, sql string, args ...interface{}) (pgx.Rows, error)
-
-	// QueryRow is a convenience wrapper over Query. Any error that occurs while
-	// querying is deferred until calling Scan on the returned Row. That Row will
-	// error with pgx.ErrNoRows if no rows are returned.
-	QueryRow(ctx context.Context, sql string, args ...interface{}) pgx.Row
-
-	// Exec executes sql. sql can be either a prepared statement name or an SQL
-	// string. arguments should be referenced positionally from the sql string
-	// as $1, $2, etc.
-	Exec(ctx context.Context, sql string, arguments ...interface{}) (pgconn.CommandTag, error)
+	Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error)
+	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
+	Exec(ctx context.Context, sql string, arguments ...any) (pgconn.CommandTag, error)
 }
 
-// NewQuerier creates a DBQuerier that implements Querier. conn is typically
-// *pgx.Conn, pgx.Tx, or *pgxpool.Pool.
+// NewQuerier creates a DBQuerier that implements Querier.
 func NewQuerier(conn genericConn) *DBQuerier {
 	return &DBQuerier{conn: conn, types: newTypeResolver()}
-}
-
-// WithTx creates a new DBQuerier that uses the transaction to run all queries.
-func (q *DBQuerier) WithTx(tx pgx.Tx) (*DBQuerier, error) {
-	return &DBQuerier{conn: tx}, nil
 }
 
 // typeResolver looks up the pgtype.ValueTranscoder by Postgres type name.

--- a/example/enums/query.sql.go
+++ b/example/enums/query.sql.go
@@ -29,41 +29,23 @@ type Querier interface {
 	EnumInsideComposite(ctx context.Context) (Device, error)
 }
 
+var _ Querier = &DBQuerier{}
+
 type DBQuerier struct {
 	conn  genericConn   // underlying Postgres transport to use
 	types *typeResolver // resolve types by name
 }
 
-var _ Querier = &DBQuerier{}
-
-// genericConn is a connection to a Postgres database. This is usually backed by
-// *pgx.Conn, pgx.Tx, or *pgxpool.Pool.
+// genericConn is a connection like *pgx.Conn, pgx.Tx, or *pgxpool.Pool.
 type genericConn interface {
-	// Query executes sql with args. If there is an error the returned Rows will
-	// be returned in an error state. So it is allowed to ignore the error
-	// returned from Query and handle it in Rows.
-	Query(ctx context.Context, sql string, args ...interface{}) (pgx.Rows, error)
-
-	// QueryRow is a convenience wrapper over Query. Any error that occurs while
-	// querying is deferred until calling Scan on the returned Row. That Row will
-	// error with pgx.ErrNoRows if no rows are returned.
-	QueryRow(ctx context.Context, sql string, args ...interface{}) pgx.Row
-
-	// Exec executes sql. sql can be either a prepared statement name or an SQL
-	// string. arguments should be referenced positionally from the sql string
-	// as $1, $2, etc.
-	Exec(ctx context.Context, sql string, arguments ...interface{}) (pgconn.CommandTag, error)
+	Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error)
+	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
+	Exec(ctx context.Context, sql string, arguments ...any) (pgconn.CommandTag, error)
 }
 
-// NewQuerier creates a DBQuerier that implements Querier. conn is typically
-// *pgx.Conn, pgx.Tx, or *pgxpool.Pool.
+// NewQuerier creates a DBQuerier that implements Querier.
 func NewQuerier(conn genericConn) *DBQuerier {
 	return &DBQuerier{conn: conn, types: newTypeResolver()}
-}
-
-// WithTx creates a new DBQuerier that uses the transaction to run all queries.
-func (q *DBQuerier) WithTx(tx pgx.Tx) (*DBQuerier, error) {
-	return &DBQuerier{conn: tx}, nil
 }
 
 // Device represents the Postgres composite type "device".

--- a/example/erp/order/customer.sql.go
+++ b/example/erp/order/customer.sql.go
@@ -27,41 +27,23 @@ type Querier interface {
 	FindOrdersMRR(ctx context.Context) ([]FindOrdersMRRRow, error)
 }
 
+var _ Querier = &DBQuerier{}
+
 type DBQuerier struct {
 	conn  genericConn   // underlying Postgres transport to use
 	types *typeResolver // resolve types by name
 }
 
-var _ Querier = &DBQuerier{}
-
-// genericConn is a connection to a Postgres database. This is usually backed by
-// *pgx.Conn, pgx.Tx, or *pgxpool.Pool.
+// genericConn is a connection like *pgx.Conn, pgx.Tx, or *pgxpool.Pool.
 type genericConn interface {
-	// Query executes sql with args. If there is an error the returned Rows will
-	// be returned in an error state. So it is allowed to ignore the error
-	// returned from Query and handle it in Rows.
-	Query(ctx context.Context, sql string, args ...interface{}) (pgx.Rows, error)
-
-	// QueryRow is a convenience wrapper over Query. Any error that occurs while
-	// querying is deferred until calling Scan on the returned Row. That Row will
-	// error with pgx.ErrNoRows if no rows are returned.
-	QueryRow(ctx context.Context, sql string, args ...interface{}) pgx.Row
-
-	// Exec executes sql. sql can be either a prepared statement name or an SQL
-	// string. arguments should be referenced positionally from the sql string
-	// as $1, $2, etc.
-	Exec(ctx context.Context, sql string, arguments ...interface{}) (pgconn.CommandTag, error)
+	Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error)
+	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
+	Exec(ctx context.Context, sql string, arguments ...any) (pgconn.CommandTag, error)
 }
 
-// NewQuerier creates a DBQuerier that implements Querier. conn is typically
-// *pgx.Conn, pgx.Tx, or *pgxpool.Pool.
+// NewQuerier creates a DBQuerier that implements Querier.
 func NewQuerier(conn genericConn) *DBQuerier {
 	return &DBQuerier{conn: conn, types: newTypeResolver()}
-}
-
-// WithTx creates a new DBQuerier that uses the transaction to run all queries.
-func (q *DBQuerier) WithTx(tx pgx.Tx) (*DBQuerier, error) {
-	return &DBQuerier{conn: tx}, nil
 }
 
 // typeResolver looks up the pgtype.ValueTranscoder by Postgres type name.

--- a/example/function/query.sql.go
+++ b/example/function/query.sql.go
@@ -15,41 +15,23 @@ type Querier interface {
 	OutParams(ctx context.Context) ([]OutParamsRow, error)
 }
 
+var _ Querier = &DBQuerier{}
+
 type DBQuerier struct {
 	conn  genericConn   // underlying Postgres transport to use
 	types *typeResolver // resolve types by name
 }
 
-var _ Querier = &DBQuerier{}
-
-// genericConn is a connection to a Postgres database. This is usually backed by
-// *pgx.Conn, pgx.Tx, or *pgxpool.Pool.
+// genericConn is a connection like *pgx.Conn, pgx.Tx, or *pgxpool.Pool.
 type genericConn interface {
-	// Query executes sql with args. If there is an error the returned Rows will
-	// be returned in an error state. So it is allowed to ignore the error
-	// returned from Query and handle it in Rows.
-	Query(ctx context.Context, sql string, args ...interface{}) (pgx.Rows, error)
-
-	// QueryRow is a convenience wrapper over Query. Any error that occurs while
-	// querying is deferred until calling Scan on the returned Row. That Row will
-	// error with pgx.ErrNoRows if no rows are returned.
-	QueryRow(ctx context.Context, sql string, args ...interface{}) pgx.Row
-
-	// Exec executes sql. sql can be either a prepared statement name or an SQL
-	// string. arguments should be referenced positionally from the sql string
-	// as $1, $2, etc.
-	Exec(ctx context.Context, sql string, arguments ...interface{}) (pgconn.CommandTag, error)
+	Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error)
+	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
+	Exec(ctx context.Context, sql string, arguments ...any) (pgconn.CommandTag, error)
 }
 
-// NewQuerier creates a DBQuerier that implements Querier. conn is typically
-// *pgx.Conn, pgx.Tx, or *pgxpool.Pool.
+// NewQuerier creates a DBQuerier that implements Querier.
 func NewQuerier(conn genericConn) *DBQuerier {
 	return &DBQuerier{conn: conn, types: newTypeResolver()}
-}
-
-// WithTx creates a new DBQuerier that uses the transaction to run all queries.
-func (q *DBQuerier) WithTx(tx pgx.Tx) (*DBQuerier, error) {
-	return &DBQuerier{conn: tx}, nil
 }
 
 // ListItem represents the Postgres composite type "list_item".

--- a/example/go_pointer_types/query.sql.go
+++ b/example/go_pointer_types/query.sql.go
@@ -25,41 +25,23 @@ type Querier interface {
 	GenSeriesStr(ctx context.Context) ([]*string, error)
 }
 
+var _ Querier = &DBQuerier{}
+
 type DBQuerier struct {
 	conn  genericConn   // underlying Postgres transport to use
 	types *typeResolver // resolve types by name
 }
 
-var _ Querier = &DBQuerier{}
-
-// genericConn is a connection to a Postgres database. This is usually backed by
-// *pgx.Conn, pgx.Tx, or *pgxpool.Pool.
+// genericConn is a connection like *pgx.Conn, pgx.Tx, or *pgxpool.Pool.
 type genericConn interface {
-	// Query executes sql with args. If there is an error the returned Rows will
-	// be returned in an error state. So it is allowed to ignore the error
-	// returned from Query and handle it in Rows.
-	Query(ctx context.Context, sql string, args ...interface{}) (pgx.Rows, error)
-
-	// QueryRow is a convenience wrapper over Query. Any error that occurs while
-	// querying is deferred until calling Scan on the returned Row. That Row will
-	// error with pgx.ErrNoRows if no rows are returned.
-	QueryRow(ctx context.Context, sql string, args ...interface{}) pgx.Row
-
-	// Exec executes sql. sql can be either a prepared statement name or an SQL
-	// string. arguments should be referenced positionally from the sql string
-	// as $1, $2, etc.
-	Exec(ctx context.Context, sql string, arguments ...interface{}) (pgconn.CommandTag, error)
+	Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error)
+	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
+	Exec(ctx context.Context, sql string, arguments ...any) (pgconn.CommandTag, error)
 }
 
-// NewQuerier creates a DBQuerier that implements Querier. conn is typically
-// *pgx.Conn, pgx.Tx, or *pgxpool.Pool.
+// NewQuerier creates a DBQuerier that implements Querier.
 func NewQuerier(conn genericConn) *DBQuerier {
 	return &DBQuerier{conn: conn, types: newTypeResolver()}
-}
-
-// WithTx creates a new DBQuerier that uses the transaction to run all queries.
-func (q *DBQuerier) WithTx(tx pgx.Tx) (*DBQuerier, error) {
-	return &DBQuerier{conn: tx}, nil
 }
 
 // typeResolver looks up the pgtype.ValueTranscoder by Postgres type name.

--- a/example/inline_param_count/inline0/query.sql.go
+++ b/example/inline_param_count/inline0/query.sql.go
@@ -25,41 +25,23 @@ type Querier interface {
 	DeleteAuthorsByFullName(ctx context.Context, params DeleteAuthorsByFullNameParams) (pgconn.CommandTag, error)
 }
 
+var _ Querier = &DBQuerier{}
+
 type DBQuerier struct {
 	conn  genericConn   // underlying Postgres transport to use
 	types *typeResolver // resolve types by name
 }
 
-var _ Querier = &DBQuerier{}
-
-// genericConn is a connection to a Postgres database. This is usually backed by
-// *pgx.Conn, pgx.Tx, or *pgxpool.Pool.
+// genericConn is a connection like *pgx.Conn, pgx.Tx, or *pgxpool.Pool.
 type genericConn interface {
-	// Query executes sql with args. If there is an error the returned Rows will
-	// be returned in an error state. So it is allowed to ignore the error
-	// returned from Query and handle it in Rows.
-	Query(ctx context.Context, sql string, args ...interface{}) (pgx.Rows, error)
-
-	// QueryRow is a convenience wrapper over Query. Any error that occurs while
-	// querying is deferred until calling Scan on the returned Row. That Row will
-	// error with pgx.ErrNoRows if no rows are returned.
-	QueryRow(ctx context.Context, sql string, args ...interface{}) pgx.Row
-
-	// Exec executes sql. sql can be either a prepared statement name or an SQL
-	// string. arguments should be referenced positionally from the sql string
-	// as $1, $2, etc.
-	Exec(ctx context.Context, sql string, arguments ...interface{}) (pgconn.CommandTag, error)
+	Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error)
+	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
+	Exec(ctx context.Context, sql string, arguments ...any) (pgconn.CommandTag, error)
 }
 
-// NewQuerier creates a DBQuerier that implements Querier. conn is typically
-// *pgx.Conn, pgx.Tx, or *pgxpool.Pool.
+// NewQuerier creates a DBQuerier that implements Querier.
 func NewQuerier(conn genericConn) *DBQuerier {
 	return &DBQuerier{conn: conn, types: newTypeResolver()}
-}
-
-// WithTx creates a new DBQuerier that uses the transaction to run all queries.
-func (q *DBQuerier) WithTx(tx pgx.Tx) (*DBQuerier, error) {
-	return &DBQuerier{conn: tx}, nil
 }
 
 // typeResolver looks up the pgtype.ValueTranscoder by Postgres type name.

--- a/example/inline_param_count/inline1/query.sql.go
+++ b/example/inline_param_count/inline1/query.sql.go
@@ -25,41 +25,23 @@ type Querier interface {
 	DeleteAuthorsByFullName(ctx context.Context, params DeleteAuthorsByFullNameParams) (pgconn.CommandTag, error)
 }
 
+var _ Querier = &DBQuerier{}
+
 type DBQuerier struct {
 	conn  genericConn   // underlying Postgres transport to use
 	types *typeResolver // resolve types by name
 }
 
-var _ Querier = &DBQuerier{}
-
-// genericConn is a connection to a Postgres database. This is usually backed by
-// *pgx.Conn, pgx.Tx, or *pgxpool.Pool.
+// genericConn is a connection like *pgx.Conn, pgx.Tx, or *pgxpool.Pool.
 type genericConn interface {
-	// Query executes sql with args. If there is an error the returned Rows will
-	// be returned in an error state. So it is allowed to ignore the error
-	// returned from Query and handle it in Rows.
-	Query(ctx context.Context, sql string, args ...interface{}) (pgx.Rows, error)
-
-	// QueryRow is a convenience wrapper over Query. Any error that occurs while
-	// querying is deferred until calling Scan on the returned Row. That Row will
-	// error with pgx.ErrNoRows if no rows are returned.
-	QueryRow(ctx context.Context, sql string, args ...interface{}) pgx.Row
-
-	// Exec executes sql. sql can be either a prepared statement name or an SQL
-	// string. arguments should be referenced positionally from the sql string
-	// as $1, $2, etc.
-	Exec(ctx context.Context, sql string, arguments ...interface{}) (pgconn.CommandTag, error)
+	Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error)
+	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
+	Exec(ctx context.Context, sql string, arguments ...any) (pgconn.CommandTag, error)
 }
 
-// NewQuerier creates a DBQuerier that implements Querier. conn is typically
-// *pgx.Conn, pgx.Tx, or *pgxpool.Pool.
+// NewQuerier creates a DBQuerier that implements Querier.
 func NewQuerier(conn genericConn) *DBQuerier {
 	return &DBQuerier{conn: conn, types: newTypeResolver()}
-}
-
-// WithTx creates a new DBQuerier that uses the transaction to run all queries.
-func (q *DBQuerier) WithTx(tx pgx.Tx) (*DBQuerier, error) {
-	return &DBQuerier{conn: tx}, nil
 }
 
 // typeResolver looks up the pgtype.ValueTranscoder by Postgres type name.

--- a/example/inline_param_count/inline2/query.sql.go
+++ b/example/inline_param_count/inline2/query.sql.go
@@ -25,41 +25,23 @@ type Querier interface {
 	DeleteAuthorsByFullName(ctx context.Context, params DeleteAuthorsByFullNameParams) (pgconn.CommandTag, error)
 }
 
+var _ Querier = &DBQuerier{}
+
 type DBQuerier struct {
 	conn  genericConn   // underlying Postgres transport to use
 	types *typeResolver // resolve types by name
 }
 
-var _ Querier = &DBQuerier{}
-
-// genericConn is a connection to a Postgres database. This is usually backed by
-// *pgx.Conn, pgx.Tx, or *pgxpool.Pool.
+// genericConn is a connection like *pgx.Conn, pgx.Tx, or *pgxpool.Pool.
 type genericConn interface {
-	// Query executes sql with args. If there is an error the returned Rows will
-	// be returned in an error state. So it is allowed to ignore the error
-	// returned from Query and handle it in Rows.
-	Query(ctx context.Context, sql string, args ...interface{}) (pgx.Rows, error)
-
-	// QueryRow is a convenience wrapper over Query. Any error that occurs while
-	// querying is deferred until calling Scan on the returned Row. That Row will
-	// error with pgx.ErrNoRows if no rows are returned.
-	QueryRow(ctx context.Context, sql string, args ...interface{}) pgx.Row
-
-	// Exec executes sql. sql can be either a prepared statement name or an SQL
-	// string. arguments should be referenced positionally from the sql string
-	// as $1, $2, etc.
-	Exec(ctx context.Context, sql string, arguments ...interface{}) (pgconn.CommandTag, error)
+	Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error)
+	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
+	Exec(ctx context.Context, sql string, arguments ...any) (pgconn.CommandTag, error)
 }
 
-// NewQuerier creates a DBQuerier that implements Querier. conn is typically
-// *pgx.Conn, pgx.Tx, or *pgxpool.Pool.
+// NewQuerier creates a DBQuerier that implements Querier.
 func NewQuerier(conn genericConn) *DBQuerier {
 	return &DBQuerier{conn: conn, types: newTypeResolver()}
-}
-
-// WithTx creates a new DBQuerier that uses the transaction to run all queries.
-func (q *DBQuerier) WithTx(tx pgx.Tx) (*DBQuerier, error) {
-	return &DBQuerier{conn: tx}, nil
 }
 
 // typeResolver looks up the pgtype.ValueTranscoder by Postgres type name.

--- a/example/inline_param_count/inline3/query.sql.go
+++ b/example/inline_param_count/inline3/query.sql.go
@@ -25,41 +25,23 @@ type Querier interface {
 	DeleteAuthorsByFullName(ctx context.Context, firstName string, lastName string, suffix string) (pgconn.CommandTag, error)
 }
 
+var _ Querier = &DBQuerier{}
+
 type DBQuerier struct {
 	conn  genericConn   // underlying Postgres transport to use
 	types *typeResolver // resolve types by name
 }
 
-var _ Querier = &DBQuerier{}
-
-// genericConn is a connection to a Postgres database. This is usually backed by
-// *pgx.Conn, pgx.Tx, or *pgxpool.Pool.
+// genericConn is a connection like *pgx.Conn, pgx.Tx, or *pgxpool.Pool.
 type genericConn interface {
-	// Query executes sql with args. If there is an error the returned Rows will
-	// be returned in an error state. So it is allowed to ignore the error
-	// returned from Query and handle it in Rows.
-	Query(ctx context.Context, sql string, args ...interface{}) (pgx.Rows, error)
-
-	// QueryRow is a convenience wrapper over Query. Any error that occurs while
-	// querying is deferred until calling Scan on the returned Row. That Row will
-	// error with pgx.ErrNoRows if no rows are returned.
-	QueryRow(ctx context.Context, sql string, args ...interface{}) pgx.Row
-
-	// Exec executes sql. sql can be either a prepared statement name or an SQL
-	// string. arguments should be referenced positionally from the sql string
-	// as $1, $2, etc.
-	Exec(ctx context.Context, sql string, arguments ...interface{}) (pgconn.CommandTag, error)
+	Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error)
+	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
+	Exec(ctx context.Context, sql string, arguments ...any) (pgconn.CommandTag, error)
 }
 
-// NewQuerier creates a DBQuerier that implements Querier. conn is typically
-// *pgx.Conn, pgx.Tx, or *pgxpool.Pool.
+// NewQuerier creates a DBQuerier that implements Querier.
 func NewQuerier(conn genericConn) *DBQuerier {
 	return &DBQuerier{conn: conn, types: newTypeResolver()}
-}
-
-// WithTx creates a new DBQuerier that uses the transaction to run all queries.
-func (q *DBQuerier) WithTx(tx pgx.Tx) (*DBQuerier, error) {
-	return &DBQuerier{conn: tx}, nil
 }
 
 // typeResolver looks up the pgtype.ValueTranscoder by Postgres type name.

--- a/example/ltree/query.sql.go
+++ b/example/ltree/query.sql.go
@@ -21,41 +21,23 @@ type Querier interface {
 	FindLtreeInput(ctx context.Context, inLtree pgtype.Text, inLtreeArray []string) (FindLtreeInputRow, error)
 }
 
+var _ Querier = &DBQuerier{}
+
 type DBQuerier struct {
 	conn  genericConn   // underlying Postgres transport to use
 	types *typeResolver // resolve types by name
 }
 
-var _ Querier = &DBQuerier{}
-
-// genericConn is a connection to a Postgres database. This is usually backed by
-// *pgx.Conn, pgx.Tx, or *pgxpool.Pool.
+// genericConn is a connection like *pgx.Conn, pgx.Tx, or *pgxpool.Pool.
 type genericConn interface {
-	// Query executes sql with args. If there is an error the returned Rows will
-	// be returned in an error state. So it is allowed to ignore the error
-	// returned from Query and handle it in Rows.
-	Query(ctx context.Context, sql string, args ...interface{}) (pgx.Rows, error)
-
-	// QueryRow is a convenience wrapper over Query. Any error that occurs while
-	// querying is deferred until calling Scan on the returned Row. That Row will
-	// error with pgx.ErrNoRows if no rows are returned.
-	QueryRow(ctx context.Context, sql string, args ...interface{}) pgx.Row
-
-	// Exec executes sql. sql can be either a prepared statement name or an SQL
-	// string. arguments should be referenced positionally from the sql string
-	// as $1, $2, etc.
-	Exec(ctx context.Context, sql string, arguments ...interface{}) (pgconn.CommandTag, error)
+	Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error)
+	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
+	Exec(ctx context.Context, sql string, arguments ...any) (pgconn.CommandTag, error)
 }
 
-// NewQuerier creates a DBQuerier that implements Querier. conn is typically
-// *pgx.Conn, pgx.Tx, or *pgxpool.Pool.
+// NewQuerier creates a DBQuerier that implements Querier.
 func NewQuerier(conn genericConn) *DBQuerier {
 	return &DBQuerier{conn: conn, types: newTypeResolver()}
-}
-
-// WithTx creates a new DBQuerier that uses the transaction to run all queries.
-func (q *DBQuerier) WithTx(tx pgx.Tx) (*DBQuerier, error) {
-	return &DBQuerier{conn: tx}, nil
 }
 
 // typeResolver looks up the pgtype.ValueTranscoder by Postgres type name.

--- a/example/nested/query.sql.go
+++ b/example/nested/query.sql.go
@@ -17,41 +17,23 @@ type Querier interface {
 	Nested3(ctx context.Context) ([]ProductImageSetType, error)
 }
 
+var _ Querier = &DBQuerier{}
+
 type DBQuerier struct {
 	conn  genericConn   // underlying Postgres transport to use
 	types *typeResolver // resolve types by name
 }
 
-var _ Querier = &DBQuerier{}
-
-// genericConn is a connection to a Postgres database. This is usually backed by
-// *pgx.Conn, pgx.Tx, or *pgxpool.Pool.
+// genericConn is a connection like *pgx.Conn, pgx.Tx, or *pgxpool.Pool.
 type genericConn interface {
-	// Query executes sql with args. If there is an error the returned Rows will
-	// be returned in an error state. So it is allowed to ignore the error
-	// returned from Query and handle it in Rows.
-	Query(ctx context.Context, sql string, args ...interface{}) (pgx.Rows, error)
-
-	// QueryRow is a convenience wrapper over Query. Any error that occurs while
-	// querying is deferred until calling Scan on the returned Row. That Row will
-	// error with pgx.ErrNoRows if no rows are returned.
-	QueryRow(ctx context.Context, sql string, args ...interface{}) pgx.Row
-
-	// Exec executes sql. sql can be either a prepared statement name or an SQL
-	// string. arguments should be referenced positionally from the sql string
-	// as $1, $2, etc.
-	Exec(ctx context.Context, sql string, arguments ...interface{}) (pgconn.CommandTag, error)
+	Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error)
+	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
+	Exec(ctx context.Context, sql string, arguments ...any) (pgconn.CommandTag, error)
 }
 
-// NewQuerier creates a DBQuerier that implements Querier. conn is typically
-// *pgx.Conn, pgx.Tx, or *pgxpool.Pool.
+// NewQuerier creates a DBQuerier that implements Querier.
 func NewQuerier(conn genericConn) *DBQuerier {
 	return &DBQuerier{conn: conn, types: newTypeResolver()}
-}
-
-// WithTx creates a new DBQuerier that uses the transaction to run all queries.
-func (q *DBQuerier) WithTx(tx pgx.Tx) (*DBQuerier, error) {
-	return &DBQuerier{conn: tx}, nil
 }
 
 // Dimensions represents the Postgres composite type "dimensions".

--- a/example/pgcrypto/query.sql.go
+++ b/example/pgcrypto/query.sql.go
@@ -17,41 +17,23 @@ type Querier interface {
 	FindUser(ctx context.Context, email string) (FindUserRow, error)
 }
 
+var _ Querier = &DBQuerier{}
+
 type DBQuerier struct {
 	conn  genericConn   // underlying Postgres transport to use
 	types *typeResolver // resolve types by name
 }
 
-var _ Querier = &DBQuerier{}
-
-// genericConn is a connection to a Postgres database. This is usually backed by
-// *pgx.Conn, pgx.Tx, or *pgxpool.Pool.
+// genericConn is a connection like *pgx.Conn, pgx.Tx, or *pgxpool.Pool.
 type genericConn interface {
-	// Query executes sql with args. If there is an error the returned Rows will
-	// be returned in an error state. So it is allowed to ignore the error
-	// returned from Query and handle it in Rows.
-	Query(ctx context.Context, sql string, args ...interface{}) (pgx.Rows, error)
-
-	// QueryRow is a convenience wrapper over Query. Any error that occurs while
-	// querying is deferred until calling Scan on the returned Row. That Row will
-	// error with pgx.ErrNoRows if no rows are returned.
-	QueryRow(ctx context.Context, sql string, args ...interface{}) pgx.Row
-
-	// Exec executes sql. sql can be either a prepared statement name or an SQL
-	// string. arguments should be referenced positionally from the sql string
-	// as $1, $2, etc.
-	Exec(ctx context.Context, sql string, arguments ...interface{}) (pgconn.CommandTag, error)
+	Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error)
+	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
+	Exec(ctx context.Context, sql string, arguments ...any) (pgconn.CommandTag, error)
 }
 
-// NewQuerier creates a DBQuerier that implements Querier. conn is typically
-// *pgx.Conn, pgx.Tx, or *pgxpool.Pool.
+// NewQuerier creates a DBQuerier that implements Querier.
 func NewQuerier(conn genericConn) *DBQuerier {
 	return &DBQuerier{conn: conn, types: newTypeResolver()}
-}
-
-// WithTx creates a new DBQuerier that uses the transaction to run all queries.
-func (q *DBQuerier) WithTx(tx pgx.Tx) (*DBQuerier, error) {
-	return &DBQuerier{conn: tx}, nil
 }
 
 // typeResolver looks up the pgtype.ValueTranscoder by Postgres type name.

--- a/example/separate_out_dir/out/alpha_query.sql.0.go
+++ b/example/separate_out_dir/out/alpha_query.sql.0.go
@@ -21,41 +21,23 @@ type Querier interface {
 	Bravo(ctx context.Context) (string, error)
 }
 
+var _ Querier = &DBQuerier{}
+
 type DBQuerier struct {
 	conn  genericConn   // underlying Postgres transport to use
 	types *typeResolver // resolve types by name
 }
 
-var _ Querier = &DBQuerier{}
-
-// genericConn is a connection to a Postgres database. This is usually backed by
-// *pgx.Conn, pgx.Tx, or *pgxpool.Pool.
+// genericConn is a connection like *pgx.Conn, pgx.Tx, or *pgxpool.Pool.
 type genericConn interface {
-	// Query executes sql with args. If there is an error the returned Rows will
-	// be returned in an error state. So it is allowed to ignore the error
-	// returned from Query and handle it in Rows.
-	Query(ctx context.Context, sql string, args ...interface{}) (pgx.Rows, error)
-
-	// QueryRow is a convenience wrapper over Query. Any error that occurs while
-	// querying is deferred until calling Scan on the returned Row. That Row will
-	// error with pgx.ErrNoRows if no rows are returned.
-	QueryRow(ctx context.Context, sql string, args ...interface{}) pgx.Row
-
-	// Exec executes sql. sql can be either a prepared statement name or an SQL
-	// string. arguments should be referenced positionally from the sql string
-	// as $1, $2, etc.
-	Exec(ctx context.Context, sql string, arguments ...interface{}) (pgconn.CommandTag, error)
+	Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error)
+	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
+	Exec(ctx context.Context, sql string, arguments ...any) (pgconn.CommandTag, error)
 }
 
-// NewQuerier creates a DBQuerier that implements Querier. conn is typically
-// *pgx.Conn, pgx.Tx, or *pgxpool.Pool.
+// NewQuerier creates a DBQuerier that implements Querier.
 func NewQuerier(conn genericConn) *DBQuerier {
 	return &DBQuerier{conn: conn, types: newTypeResolver()}
-}
-
-// WithTx creates a new DBQuerier that uses the transaction to run all queries.
-func (q *DBQuerier) WithTx(tx pgx.Tx) (*DBQuerier, error) {
-	return &DBQuerier{conn: tx}, nil
 }
 
 // Alpha represents the Postgres composite type "alpha".

--- a/example/slices/query.sql.go
+++ b/example/slices/query.sql.go
@@ -22,41 +22,23 @@ type Querier interface {
 	GetManyTimestamps(ctx context.Context, data []*time.Time) ([]*time.Time, error)
 }
 
+var _ Querier = &DBQuerier{}
+
 type DBQuerier struct {
 	conn  genericConn   // underlying Postgres transport to use
 	types *typeResolver // resolve types by name
 }
 
-var _ Querier = &DBQuerier{}
-
-// genericConn is a connection to a Postgres database. This is usually backed by
-// *pgx.Conn, pgx.Tx, or *pgxpool.Pool.
+// genericConn is a connection like *pgx.Conn, pgx.Tx, or *pgxpool.Pool.
 type genericConn interface {
-	// Query executes sql with args. If there is an error the returned Rows will
-	// be returned in an error state. So it is allowed to ignore the error
-	// returned from Query and handle it in Rows.
-	Query(ctx context.Context, sql string, args ...interface{}) (pgx.Rows, error)
-
-	// QueryRow is a convenience wrapper over Query. Any error that occurs while
-	// querying is deferred until calling Scan on the returned Row. That Row will
-	// error with pgx.ErrNoRows if no rows are returned.
-	QueryRow(ctx context.Context, sql string, args ...interface{}) pgx.Row
-
-	// Exec executes sql. sql can be either a prepared statement name or an SQL
-	// string. arguments should be referenced positionally from the sql string
-	// as $1, $2, etc.
-	Exec(ctx context.Context, sql string, arguments ...interface{}) (pgconn.CommandTag, error)
+	Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error)
+	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
+	Exec(ctx context.Context, sql string, arguments ...any) (pgconn.CommandTag, error)
 }
 
-// NewQuerier creates a DBQuerier that implements Querier. conn is typically
-// *pgx.Conn, pgx.Tx, or *pgxpool.Pool.
+// NewQuerier creates a DBQuerier that implements Querier.
 func NewQuerier(conn genericConn) *DBQuerier {
 	return &DBQuerier{conn: conn, types: newTypeResolver()}
-}
-
-// WithTx creates a new DBQuerier that uses the transaction to run all queries.
-func (q *DBQuerier) WithTx(tx pgx.Tx) (*DBQuerier, error) {
-	return &DBQuerier{conn: tx}, nil
 }
 
 // typeResolver looks up the pgtype.ValueTranscoder by Postgres type name.

--- a/example/syntax/query.sql.go
+++ b/example/syntax/query.sql.go
@@ -39,41 +39,23 @@ type Querier interface {
 	GoKeyword(ctx context.Context, go_ string) (string, error)
 }
 
+var _ Querier = &DBQuerier{}
+
 type DBQuerier struct {
 	conn  genericConn   // underlying Postgres transport to use
 	types *typeResolver // resolve types by name
 }
 
-var _ Querier = &DBQuerier{}
-
-// genericConn is a connection to a Postgres database. This is usually backed by
-// *pgx.Conn, pgx.Tx, or *pgxpool.Pool.
+// genericConn is a connection like *pgx.Conn, pgx.Tx, or *pgxpool.Pool.
 type genericConn interface {
-	// Query executes sql with args. If there is an error the returned Rows will
-	// be returned in an error state. So it is allowed to ignore the error
-	// returned from Query and handle it in Rows.
-	Query(ctx context.Context, sql string, args ...interface{}) (pgx.Rows, error)
-
-	// QueryRow is a convenience wrapper over Query. Any error that occurs while
-	// querying is deferred until calling Scan on the returned Row. That Row will
-	// error with pgx.ErrNoRows if no rows are returned.
-	QueryRow(ctx context.Context, sql string, args ...interface{}) pgx.Row
-
-	// Exec executes sql. sql can be either a prepared statement name or an SQL
-	// string. arguments should be referenced positionally from the sql string
-	// as $1, $2, etc.
-	Exec(ctx context.Context, sql string, arguments ...interface{}) (pgconn.CommandTag, error)
+	Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error)
+	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
+	Exec(ctx context.Context, sql string, arguments ...any) (pgconn.CommandTag, error)
 }
 
-// NewQuerier creates a DBQuerier that implements Querier. conn is typically
-// *pgx.Conn, pgx.Tx, or *pgxpool.Pool.
+// NewQuerier creates a DBQuerier that implements Querier.
 func NewQuerier(conn genericConn) *DBQuerier {
 	return &DBQuerier{conn: conn, types: newTypeResolver()}
-}
-
-// WithTx creates a new DBQuerier that uses the transaction to run all queries.
-func (q *DBQuerier) WithTx(tx pgx.Tx) (*DBQuerier, error) {
-	return &DBQuerier{conn: tx}, nil
 }
 
 // UnnamedEnum123 represents the Postgres enum "123".

--- a/example/void/query.sql.go
+++ b/example/void/query.sql.go
@@ -23,41 +23,23 @@ type Querier interface {
 	VoidThree2(ctx context.Context) ([]string, error)
 }
 
+var _ Querier = &DBQuerier{}
+
 type DBQuerier struct {
 	conn  genericConn   // underlying Postgres transport to use
 	types *typeResolver // resolve types by name
 }
 
-var _ Querier = &DBQuerier{}
-
-// genericConn is a connection to a Postgres database. This is usually backed by
-// *pgx.Conn, pgx.Tx, or *pgxpool.Pool.
+// genericConn is a connection like *pgx.Conn, pgx.Tx, or *pgxpool.Pool.
 type genericConn interface {
-	// Query executes sql with args. If there is an error the returned Rows will
-	// be returned in an error state. So it is allowed to ignore the error
-	// returned from Query and handle it in Rows.
-	Query(ctx context.Context, sql string, args ...interface{}) (pgx.Rows, error)
-
-	// QueryRow is a convenience wrapper over Query. Any error that occurs while
-	// querying is deferred until calling Scan on the returned Row. That Row will
-	// error with pgx.ErrNoRows if no rows are returned.
-	QueryRow(ctx context.Context, sql string, args ...interface{}) pgx.Row
-
-	// Exec executes sql. sql can be either a prepared statement name or an SQL
-	// string. arguments should be referenced positionally from the sql string
-	// as $1, $2, etc.
-	Exec(ctx context.Context, sql string, arguments ...interface{}) (pgconn.CommandTag, error)
+	Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error)
+	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
+	Exec(ctx context.Context, sql string, arguments ...any) (pgconn.CommandTag, error)
 }
 
-// NewQuerier creates a DBQuerier that implements Querier. conn is typically
-// *pgx.Conn, pgx.Tx, or *pgxpool.Pool.
+// NewQuerier creates a DBQuerier that implements Querier.
 func NewQuerier(conn genericConn) *DBQuerier {
 	return &DBQuerier{conn: conn, types: newTypeResolver()}
-}
-
-// WithTx creates a new DBQuerier that uses the transaction to run all queries.
-func (q *DBQuerier) WithTx(tx pgx.Tx) (*DBQuerier, error) {
-	return &DBQuerier{conn: tx}, nil
 }
 
 // typeResolver looks up the pgtype.ValueTranscoder by Postgres type name.

--- a/internal/codegen/golang/query.gotemplate
+++ b/internal/codegen/golang/query.gotemplate
@@ -24,41 +24,23 @@ type Querier interface {
 {{- end -}}
 }
 
+var _ Querier = &DBQuerier{}
+
 type DBQuerier struct {
 	conn  genericConn   // underlying Postgres transport to use
 	types *typeResolver // resolve types by name
 }
 
-var _ Querier = &DBQuerier{}
-
-// genericConn is a connection to a Postgres database. This is usually backed by
-// *pgx.Conn, pgx.Tx, or *pgxpool.Pool.
+// genericConn is a connection like *pgx.Conn, pgx.Tx, or *pgxpool.Pool.
 type genericConn interface {
-	// Query executes sql with args. If there is an error the returned Rows will
-	// be returned in an error state. So it is allowed to ignore the error
-	// returned from Query and handle it in Rows.
-	Query(ctx context.Context, sql string, args ...interface{}) (pgx.Rows, error)
-
-	// QueryRow is a convenience wrapper over Query. Any error that occurs while
-	// querying is deferred until calling Scan on the returned Row. That Row will
-	// error with pgx.ErrNoRows if no rows are returned.
-	QueryRow(ctx context.Context, sql string, args ...interface{}) pgx.Row
-
-	// Exec executes sql. sql can be either a prepared statement name or an SQL
-	// string. arguments should be referenced positionally from the sql string
-	// as $1, $2, etc.
-	Exec(ctx context.Context, sql string, arguments ...interface{}) (pgconn.CommandTag, error)
+	Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error)
+	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
+	Exec(ctx context.Context, sql string, arguments ...any) (pgconn.CommandTag, error)
 }
 
-// NewQuerier creates a DBQuerier that implements Querier. conn is typically
-// *pgx.Conn, pgx.Tx, or *pgxpool.Pool.
+// NewQuerier creates a DBQuerier that implements Querier.
 func NewQuerier(conn genericConn) *DBQuerier {
 	return &DBQuerier{conn: conn, types: newTypeResolver()}
-}
-
-// WithTx creates a new DBQuerier that uses the transaction to run all queries.
-func (q *DBQuerier) WithTx(tx pgx.Tx) (*DBQuerier, error) {
-	return &DBQuerier{conn: tx}, nil
 }
 
 {{- range .Declarers}}{{- "\n\n" -}}{{ .Declare $.PkgPath }}{{ end -}}

--- a/internal/pg/query.sql.go
+++ b/internal/pg/query.sql.go
@@ -32,41 +32,23 @@ type Querier interface {
 	FindOIDNames(ctx context.Context, oid []uint32) ([]FindOIDNamesRow, error)
 }
 
+var _ Querier = &DBQuerier{}
+
 type DBQuerier struct {
 	conn  genericConn   // underlying Postgres transport to use
 	types *typeResolver // resolve types by name
 }
 
-var _ Querier = &DBQuerier{}
-
-// genericConn is a connection to a Postgres database. This is usually backed by
-// *pgx.Conn, pgx.Tx, or *pgxpool.Pool.
+// genericConn is a connection like *pgx.Conn, pgx.Tx, or *pgxpool.Pool.
 type genericConn interface {
-	// Query executes sql with args. If there is an error the returned Rows will
-	// be returned in an error state. So it is allowed to ignore the error
-	// returned from Query and handle it in Rows.
-	Query(ctx context.Context, sql string, args ...interface{}) (pgx.Rows, error)
-
-	// QueryRow is a convenience wrapper over Query. Any error that occurs while
-	// querying is deferred until calling Scan on the returned Row. That Row will
-	// error with pgx.ErrNoRows if no rows are returned.
-	QueryRow(ctx context.Context, sql string, args ...interface{}) pgx.Row
-
-	// Exec executes sql. sql can be either a prepared statement name or an SQL
-	// string. arguments should be referenced positionally from the sql string
-	// as $1, $2, etc.
-	Exec(ctx context.Context, sql string, arguments ...interface{}) (pgconn.CommandTag, error)
+	Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error)
+	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
+	Exec(ctx context.Context, sql string, arguments ...any) (pgconn.CommandTag, error)
 }
 
-// NewQuerier creates a DBQuerier that implements Querier. conn is typically
-// *pgx.Conn, pgx.Tx, or *pgxpool.Pool.
+// NewQuerier creates a DBQuerier that implements Querier.
 func NewQuerier(conn genericConn) *DBQuerier {
 	return &DBQuerier{conn: conn, types: newTypeResolver()}
-}
-
-// WithTx creates a new DBQuerier that uses the transaction to run all queries.
-func (q *DBQuerier) WithTx(tx pgx.Tx) (*DBQuerier, error) {
-	return &DBQuerier{conn: tx}, nil
 }
 
 // typeResolver looks up the pgtype.ValueTranscoder by Postgres type name.


### PR DESCRIPTION
We don't need the wordy description in every generated file.